### PR TITLE
fix: light mode header background and theme switching

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -9,6 +9,11 @@
   box-shadow: 0 2px 20px rgba(0, 200, 255, 0.1);
 }
 
+[data-mode="light"] .site-header {
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+}
+
 .site-header__inner {
   max-width: 72rem;
   margin: 0 auto;

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -69,20 +69,20 @@
 
 /* Light mode - applies to all themes via data-mode attribute */
 [data-mode="light"] {
-  --color-bg: #f8f9fa !important;
-  --color-bg-alt: #e9ecef !important;
-  --color-surface: #ffffff !important;
-  --color-surface-hover: #f1f3f5 !important;
-  --color-text: #212529 !important;
-  --color-text-muted: #6c757d !important;
-  --color-border: #dee2e6 !important;
-  --color-accent: #0066cc !important;
-  --color-accent-hover: #0052a3 !important;
-  --color-accent-dim: rgba(0, 102, 204, 0.1) !important;
-  --color-code-bg: #f1f3f5 !important;
-  --color-quote-border: #0066cc !important;
-  --shadow-card: 0 2px 8px rgba(0, 0, 0, 0.1) !important;
-  --glow-accent: 0 0 6px rgba(0, 102, 204, 0.4) !important;
+  --color-bg: #f8f9fa;
+  --color-bg-alt: #e9ecef;
+  --color-surface: #ffffff;
+  --color-surface-hover: #f1f3f5;
+  --color-text: #212529;
+  --color-text-muted: #6c757d;
+  --color-border: #dee2e6;
+  --color-accent: #0066cc;
+  --color-accent-hover: #0052a3;
+  --color-accent-dim: rgba(0, 102, 204, 0.1);
+  --color-code-bg: #f1f3f5;
+  --color-quote-border: #0066cc;
+  --shadow-card: 0 2px 8px rgba(0, 0, 0, 0.1);
+  --glow-accent: 0 0 6px rgba(0, 102, 204, 0.4);
   --preview: #0066cc;
 }
 


### PR DESCRIPTION
## Summary

Two light mode bugs fixed:

1. **Header background too dark** — `.site-header` had hardcoded `rgba(10,10,15,0.85)`. Added `[data-mode="light"] .site-header` override with `rgba(255,255,255,0.85)` and softer shadow.

2. **Theme switching broken in light mode** — Base `[data-mode="light"]` rules used `!important` on every CSS variable, which prevented theme-specific light variants (`[data-theme="aurora"][data-mode="light"]` etc.) from overriding them. Removed `!important` so CSS specificity cascade works naturally.

## Files changed

- `css/components.css` — add light mode header override
- `css/tokens.css` — remove `!important` from base light mode variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)