### PR TITLE
feat(T1.3): add 10 admin v2 tables (RBAC + audit + multi-site)

### DIFF
--- a/server/scripts/check-tables.js
+++ b/server/scripts/check-tables.js
@@ -1,0 +1,44 @@
+// One-off helper: list all tables in db/blog.sqlite
+// Usage (from server/): node scripts/check-tables.js
+const path = require("node:path");
+const Database = require("better-sqlite3");
+
+const dbPath = path.join(__dirname, "..", "db", "blog.sqlite");
+const db = new Database(dbPath, { readonly: true });
+
+const rows = db
+  .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+  .all();
+
+const names = rows.map((row) => row["name"]);
+console.log(names.join("\n"));
+console.log("");
+console.log("Total tables:", names.length);
+
+const expected = [
+  // legacy (camelCase)
+  "posts",
+  "tags",
+  "post_tags",
+  "categories",
+  "post_categories",
+  "external_links",
+  // v2 (snake_case)
+  "users",
+  "roles",
+  "user_roles",
+  "permissions",
+  "role_permissions",
+  "menus",
+  "audit_logs",
+  "sites",
+  "front_users",
+  "page_views",
+];
+const missing = expected.filter((t) => !names.includes(t));
+if (missing.length === 0) {
+  console.log("OK: all 16 expected tables exist.");
+} else {
+  console.log("MISSING:", missing.join(", "));
+  process.exit(1);
+}

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -74,6 +74,140 @@ function migrate(db) {
     CREATE INDEX IF NOT EXISTS idx_post_tags_tagId ON post_tags(tagId);
     CREATE INDEX IF NOT EXISTS idx_post_categories_categoryId ON post_categories(categoryId);
     CREATE INDEX IF NOT EXISTS idx_external_links_sortOrder ON external_links(sortOrder);
+
+    -- ============================================================
+    -- Phase 1 (Admin v2): RBAC + 审计 + 多站点 + 前台读者预留
+    -- 新表统一使用 snake_case，与旧表的 camelCase 区分；通过这种命名
+    -- 风格差异即可一眼看出是 v2 域的表。详见 docs/04-admin-architecture.md §5。
+    -- ============================================================
+
+    -- 5.1 后台用户
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT NOT NULL UNIQUE,
+      email TEXT NOT NULL UNIQUE,
+      password_hash TEXT NOT NULL,
+      display_name TEXT,
+      avatar_url TEXT,
+      status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'disabled')),
+      is_super_admin INTEGER NOT NULL DEFAULT 0,
+      last_login_at TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    -- 5.2 角色
+    CREATE TABLE IF NOT EXISTS roles (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      code TEXT NOT NULL UNIQUE,
+      description TEXT,
+      status TEXT NOT NULL DEFAULT 'active',
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    -- 5.3 用户-角色关联
+    CREATE TABLE IF NOT EXISTS user_roles (
+      user_id INTEGER NOT NULL,
+      role_id INTEGER NOT NULL,
+      PRIMARY KEY (user_id, role_id),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+    );
+
+    -- 5.4 权限（资源:操作 格式）
+    CREATE TABLE IF NOT EXISTS permissions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      code TEXT NOT NULL UNIQUE,
+      resource TEXT NOT NULL,
+      action TEXT NOT NULL,
+      description TEXT,
+      created_at TEXT NOT NULL
+    );
+
+    -- 5.5 角色-权限关联
+    CREATE TABLE IF NOT EXISTS role_permissions (
+      role_id INTEGER NOT NULL,
+      permission_id INTEGER NOT NULL,
+      PRIMARY KEY (role_id, permission_id),
+      FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE,
+      FOREIGN KEY (permission_id) REFERENCES permissions(id) ON DELETE CASCADE
+    );
+
+    -- 5.6 后台菜单（树形）
+    CREATE TABLE IF NOT EXISTS menus (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      parent_id INTEGER DEFAULT NULL REFERENCES menus(id),
+      name TEXT NOT NULL,
+      path TEXT,
+      icon TEXT,
+      permission_code TEXT,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'active',
+      created_at TEXT NOT NULL
+    );
+
+    -- 5.7 操作审计日志
+    CREATE TABLE IF NOT EXISTS audit_logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER REFERENCES users(id),
+      username TEXT,
+      action TEXT NOT NULL,
+      resource_type TEXT NOT NULL,
+      resource_id TEXT,
+      detail TEXT,
+      ip TEXT,
+      user_agent TEXT,
+      created_at TEXT NOT NULL
+    );
+
+    -- 5.8 多站点（预留）
+    CREATE TABLE IF NOT EXISTS sites (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      slug TEXT NOT NULL UNIQUE,
+      domain TEXT,
+      description TEXT,
+      status TEXT NOT NULL DEFAULT 'active',
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    -- 5.9 前台读者用户（预留：评论/收藏体系）
+    CREATE TABLE IF NOT EXISTS front_users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT NOT NULL UNIQUE,
+      email TEXT NOT NULL UNIQUE,
+      password_hash TEXT NOT NULL,
+      display_name TEXT,
+      avatar_url TEXT,
+      status TEXT NOT NULL DEFAULT 'active',
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    -- 5.10 访问统计原始记录
+    CREATE TABLE IF NOT EXISTS page_views (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      path TEXT NOT NULL,
+      referrer TEXT,
+      ip TEXT,
+      user_agent TEXT,
+      session_id TEXT,
+      front_user_id INTEGER REFERENCES front_users(id),
+      created_at TEXT NOT NULL
+    );
+
+    -- v2 索引
+    CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
+    CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+    CREATE INDEX IF NOT EXISTS idx_permissions_code ON permissions(code);
+    CREATE INDEX IF NOT EXISTS idx_audit_logs_user_id ON audit_logs(user_id);
+    CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at ON audit_logs(created_at);
+    CREATE INDEX IF NOT EXISTS idx_page_views_created_at ON page_views(created_at);
+    CREATE INDEX IF NOT EXISTS idx_page_views_path ON page_views(path);
   `);
 }
 


### PR DESCRIPTION
Tables: users, roles, user_roles, permissions, role_permissions, menus, audit_logs, sites, front_users, page_views.

Indexes: idx_users_username, idx_users_email, idx_permissions_code, idx_audit_logs_user_id, idx_audit_logs_created_at, idx_page_views_created_at, idx_page_views_path.

Convention: v2 tables use snake_case to distinguish from legacy camelCase. All CREATE TABLE IF NOT EXISTS for idempotent migration. Add server/scripts/check-tables.js helper for verifying schema state.

Closes #7
