### PR TITLE
feat(T1.4): RBAC seed - 12 perms, 3 roles, super admin, default menu

### DIFF
--- a/server/scripts/check-rbac-seed.js
+++ b/server/scripts/check-rbac-seed.js
@@ -1,0 +1,92 @@
+// One-off helper: verify RBAC seed data
+// Usage (from server/): node scripts/check-rbac-seed.js
+const path = require("node:path");
+const Database = require("better-sqlite3");
+
+const dbPath = path.join(__dirname, "..", "db", "blog.sqlite");
+const db = new Database(dbPath, { readonly: true });
+
+let pass = true;
+function check(label, ok, detail) {
+  const tag = ok ? "OK  " : "FAIL";
+  console.log(`[${tag}] ${label}${detail ? "  -- " + detail : ""}`);
+  if (!ok) pass = false;
+}
+
+// 1) permissions
+const permCount = db.prepare("SELECT COUNT(*) AS c FROM permissions").get().c;
+check("permissions = 12", permCount === 12, `actual=${permCount}`);
+
+const expectedPerms = [
+  "post:list","post:create","post:update","post:delete","post:publish",
+  "user:list","user:create","role:assign",
+  "analytics:view","ops:backup","ops:logs","menu:manage",
+];
+const actualPerms = db.prepare("SELECT code FROM permissions ORDER BY code").all().map(r => r.code);
+const missingPerms = expectedPerms.filter(c => !actualPerms.includes(c));
+check("all 12 permission codes present", missingPerms.length === 0, missingPerms.length ? "missing: " + missingPerms.join(",") : "");
+
+// 2) roles
+const roleCount = db.prepare("SELECT COUNT(*) AS c FROM roles").get().c;
+check("roles = 3", roleCount === 3, `actual=${roleCount}`);
+
+for (const code of ["super_admin","content_admin","viewer"]) {
+  const r = db.prepare("SELECT name FROM roles WHERE code = ?").get(code);
+  check(`role exists: ${code}`, !!r, r ? `name=${r.name}` : "");
+}
+
+// 3) super_admin role bound to all 12 permissions
+const saPerms = db.prepare(`
+  SELECT COUNT(*) AS c
+  FROM role_permissions rp
+  JOIN roles r ON r.id = rp.role_id
+  WHERE r.code = 'super_admin'
+`).get().c;
+check("super_admin bound to all 12 permissions", saPerms === 12, `actual=${saPerms}`);
+
+// content_admin: 6 permissions (5 post:* + analytics:view)
+const caPerms = db.prepare(`
+  SELECT COUNT(*) AS c
+  FROM role_permissions rp
+  JOIN roles r ON r.id = rp.role_id
+  WHERE r.code = 'content_admin'
+`).get().c;
+check("content_admin bound to 6 permissions", caPerms === 6, `actual=${caPerms}`);
+
+// viewer: 4 permissions
+const vPerms = db.prepare(`
+  SELECT COUNT(*) AS c
+  FROM role_permissions rp
+  JOIN roles r ON r.id = rp.role_id
+  WHERE r.code = 'viewer'
+`).get().c;
+check("viewer bound to 4 permissions", vPerms === 4, `actual=${vPerms}`);
+
+// 4) super admin user
+const su = db.prepare(`
+  SELECT id, username, email, is_super_admin, status
+  FROM users WHERE is_super_admin = 1
+`).all();
+check("super admin user count = 1", su.length === 1, su.length ? `email=${su[0].email}, username=${su[0].username}` : "");
+
+// 5) super admin bound to super_admin role
+if (su.length === 1) {
+  const bound = db.prepare(`
+    SELECT COUNT(*) AS c
+    FROM user_roles ur
+    JOIN roles r ON r.id = ur.role_id
+    WHERE ur.user_id = ? AND r.code = 'super_admin'
+  `).get(su[0].id).c;
+  check("super admin user bound to super_admin role", bound === 1);
+}
+
+// 6) menus
+const menuTotal = db.prepare("SELECT COUNT(*) AS c FROM menus").get().c;
+check("menus total >= 15 (5 top + children)", menuTotal >= 15, `actual=${menuTotal}`);
+
+const topMenus = db.prepare("SELECT name FROM menus WHERE parent_id IS NULL ORDER BY sort_order").all().map(r => r.name);
+check("5 top-level menus", topMenus.length === 5, `actual=[${topMenus.join(", ")}]`);
+
+console.log("");
+console.log(pass ? "PASS: RBAC seed verified." : "FAIL: see [FAIL] entries above.");
+process.exit(pass ? 0 : 1);

--- a/server/scripts/run-migrations.js
+++ b/server/scripts/run-migrations.js
@@ -1,0 +1,31 @@
+// One-off helper: run migration + all seeds without starting the HTTP server.
+// Usage (from server/): node scripts/run-migrations.js
+//
+// 用途：T1.4 验证、CI 校验、首次部署时不想启 server 也能初始化 DB。
+
+const path = require("node:path");
+
+// 加载 .env
+require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
+
+const { optional } = require("../src/env");
+const { openDb, migrate, ensureSeed } = require("../src/db");
+const { ensureRbacSeed } = require("../src/seeds/rbacSeed");
+
+const ADMIN_EMAIL = optional("ADMIN_EMAIL", "admin@example.com");
+const ADMIN_PASSWORD = optional("ADMIN_PASSWORD", "admin");
+const ADMIN_PASSWORD_HASH = optional("ADMIN_PASSWORD_HASH", "");
+
+const db = openDb();
+migrate(db);
+ensureSeed(db);
+ensureRbacSeed(db, {
+  adminEmail: ADMIN_EMAIL,
+  adminPassword: ADMIN_PASSWORD,
+  adminPasswordHash: ADMIN_PASSWORD_HASH,
+});
+
+console.log("Migration + seed done.");
+console.log("  admin email :", ADMIN_EMAIL);
+console.log("  admin source:", ADMIN_PASSWORD_HASH ? "ADMIN_PASSWORD_HASH" : "ADMIN_PASSWORD (auto bcrypt)");
+db.close();

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -10,6 +10,7 @@ require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
 
 const { optional, required } = require("./env");
 const { openDb, migrate, ensureSeed, listTagsForPost, listTagsForPosts, listCategoriesForPosts, setPostTags, listCategoriesForPost, setPostCategories } = require("./db");
+const { ensureRbacSeed } = require("./seeds/rbacSeed");
 const { renderMarkdownToSafeHtml } = require("./markdown");
 const { nowIso, normalizeSlug, splitTags, toInt } = require("./utils");
 const { verifyAdminLogin, requireAdmin, requireAdminPage } = require("./auth");
@@ -58,6 +59,11 @@ function safeUrl(s, { allowDataImage = false } = {}) {
 const db = openDb();
 migrate(db);
 ensureSeed(db);
+ensureRbacSeed(db, {
+  adminEmail: ADMIN_EMAIL,
+  adminPassword: ADMIN_PASSWORD,
+  adminPasswordHash: ADMIN_PASSWORD_HASH,
+});
 
 const storage = multer.diskStorage({
   destination: (req, file, cb) => cb(null, UPLOAD_DIR),

--- a/server/src/seeds/README.md
+++ b/server/src/seeds/README.md
@@ -1,0 +1,22 @@
+# server/src/seeds/
+
+数据库种子（seed）脚本 — 系统首次启动时初始化必要的内置数据。
+
+## 文件清单
+
+| 文件 | 用途 | Phase |
+|------|------|-------|
+| `rbacSeed.js` | RBAC 基础数据：12 权限 / 3 角色 / 默认菜单 / 超管账号迁移 | T1.4 |
+
+## 设计约定
+
+- **幂等**：所有 seed 必须可以重复执行不报错（`INSERT OR IGNORE` / 存在性判断 / 行计数判空）。
+- **导出方式**：每个 seed 文件导出一个 `ensureXxxSeed(db, options)` 函数，由 `src/index.js` 启动尾部统一调用。
+- **职责单一**：每个 seed 只关心自己那块内置数据，不跨模块写入。
+- **依赖顺序**：所有 seed 在 `migrate(db)` 之后运行。如果 seed 之间有依赖（例如 user_roles 依赖 users + roles），同一个 seed 内用 `db.transaction` 包裹。
+
+## 详见
+
+- 数据初始化清单：[`docs/04-admin-architecture.md`](../../../docs/04-admin-architecture.md) §7.5
+- 12 权限码定义：[`docs/04-admin-architecture.md`](../../../docs/04-admin-architecture.md) §7.3
+- 实施任务：[`docs/05-implementation-plan.md`](../../../docs/05-implementation-plan.md) T1.4

--- a/server/src/seeds/rbacSeed.js
+++ b/server/src/seeds/rbacSeed.js
@@ -1,0 +1,253 @@
+/**
+ * RBAC seed data for Phase 1 (T1.4).
+ *
+ * 在系统首次启动时初始化：
+ *   1) 12 条基础权限 (permissions)
+ *   2) 3 个基础角色 (roles)
+ *   3) 角色-权限绑定 (role_permissions)
+ *   4) 超管账号 (users) —— 从 .env 的 ADMIN_EMAIL/ADMIN_PASSWORD 迁移
+ *   5) 超管角色绑定 (user_roles)
+ *   6) 默认菜单树 (menus)
+ *
+ * 全部使用 INSERT OR IGNORE / 存在性判断，幂等可重复跑。
+ * 详见 docs/04-admin-architecture.md §7.3 / §7.5。
+ */
+
+const bcrypt = require("bcryptjs");
+const { nowIso } = require("../utils");
+
+// ============================================================
+// 1) 权限 —— 12 条
+// ============================================================
+const PERMISSIONS = [
+  { code: "post:list",      resource: "post",      action: "list",      name: "查看文章列表",   description: "浏览文章列表与详情" },
+  { code: "post:create",    resource: "post",      action: "create",    name: "创建文章",       description: "新建草稿与文章" },
+  { code: "post:update",    resource: "post",      action: "update",    name: "编辑文章",       description: "修改已有文章内容" },
+  { code: "post:delete",    resource: "post",      action: "delete",    name: "删除文章",       description: "永久删除文章" },
+  { code: "post:publish",   resource: "post",      action: "publish",   name: "发布/下架文章",  description: "切换文章发布状态" },
+  { code: "user:list",      resource: "user",      action: "list",      name: "查看用户",       description: "浏览后台用户列表" },
+  { code: "user:create",    resource: "user",      action: "create",    name: "创建用户",       description: "新增后台用户" },
+  { code: "role:assign",    resource: "role",      action: "assign",    name: "分配角色",       description: "管理角色及其权限" },
+  { code: "analytics:view", resource: "analytics", action: "view",      name: "查看数据统计",   description: "访问数据分析仪表盘" },
+  { code: "ops:backup",     resource: "ops",       action: "backup",    name: "执行备份",       description: "触发数据库备份任务" },
+  { code: "ops:logs",       resource: "ops",       action: "logs",      name: "查看审计日志",   description: "浏览操作审计日志" },
+  { code: "menu:manage",    resource: "menu",      action: "manage",    name: "管理后台菜单",   description: "维护后台侧边栏菜单" },
+];
+
+// ============================================================
+// 2) 角色 + 权限绑定
+// ============================================================
+const ROLES = [
+  {
+    code: "super_admin",
+    name: "超级管理员",
+    description: "拥有全部权限（实际靠 users.is_super_admin=1 跳过 RBAC，此处绑定关系仅为可读审计）",
+    permissions: "*", // 全部
+  },
+  {
+    code: "content_admin",
+    name: "内容管理员",
+    description: "可管理博客内容（文章 / 标签 / 分类 / 友链）",
+    permissions: ["post:list", "post:create", "post:update", "post:delete", "post:publish", "analytics:view"],
+  },
+  {
+    code: "viewer",
+    name: "访客/只读",
+    description: "只能浏览数据，不能修改",
+    permissions: ["post:list", "user:list", "analytics:view", "ops:logs"],
+  },
+];
+
+// ============================================================
+// 3) 默认菜单树
+// 命名约定：parent 为 null 即顶级；children 数组为子项
+// permission_code 表示访问该菜单需要的权限（super_admin 自动放行）
+// ============================================================
+const MENUS = [
+  { name: "仪表盘",   path: "/cms/dashboard", icon: "DashboardOutline",     permission: null,             sort: 1 },
+  {
+    name: "博客管理", path: null,             icon: "DocumentTextOutline",  permission: "post:list",      sort: 2,
+    children: [
+      { name: "文章",   path: "/cms/posts",      icon: "DocumentOutline",   permission: "post:list" },
+      { name: "标签",   path: "/cms/tags",       icon: "PricetagOutline",   permission: "post:list" },
+      { name: "分类",   path: "/cms/categories", icon: "FolderOutline",     permission: "post:list" },
+      { name: "友链",   path: "/cms/links",      icon: "LinkOutline",       permission: "post:list" },
+      { name: "媒体库", path: "/cms/media",      icon: "ImageOutline",      permission: "post:list" },
+    ],
+  },
+  {
+    name: "权限管理", path: null, icon: "ShieldCheckmarkOutline", permission: "user:list", sort: 3,
+    children: [
+      { name: "用户", path: "/cms/rbac/users",       icon: "PersonOutline",        permission: "user:list" },
+      { name: "角色", path: "/cms/rbac/roles",       icon: "PeopleOutline",        permission: "role:assign" },
+      { name: "权限", path: "/cms/rbac/permissions", icon: "KeyOutline",           permission: "role:assign" },
+      { name: "菜单", path: "/cms/rbac/menus",       icon: "MenuOutline",          permission: "menu:manage" },
+    ],
+  },
+  { name: "数据分析", path: "/cms/analytics", icon: "BarChartOutline",      permission: "analytics:view", sort: 4 },
+  {
+    name: "运维",     path: null,             icon: "SettingsOutline",      permission: "ops:logs",       sort: 5,
+    children: [
+      { name: "审计日志", path: "/cms/ops/logs",    icon: "ReceiptOutline",  permission: "ops:logs" },
+      { name: "备份",     path: "/cms/ops/backup",  icon: "ArchiveOutline",  permission: "ops:backup" },
+      { name: "系统监控", path: "/cms/ops/monitor", icon: "PulseOutline",    permission: "ops:logs" },
+    ],
+  },
+];
+
+// ============================================================
+// 主入口
+// ============================================================
+function ensureRbacSeed(db, { adminEmail, adminPassword, adminPasswordHash }) {
+  const now = nowIso();
+
+  const tx = db.transaction(() => {
+    seedPermissions(db, now);
+    seedRoles(db, now);
+    seedRolePermissions(db);
+    seedSuperAdmin(db, { adminEmail, adminPassword, adminPasswordHash, now });
+    seedMenus(db, now);
+  });
+
+  tx();
+}
+
+// ----- permissions -----
+function seedPermissions(db, now) {
+  const stmt = db.prepare(`
+    INSERT OR IGNORE INTO permissions (name, code, resource, action, description, created_at)
+    VALUES (@name, @code, @resource, @action, @description, @created_at)
+  `);
+  for (const p of PERMISSIONS) {
+    stmt.run({ ...p, created_at: now });
+  }
+}
+
+// ----- roles -----
+function seedRoles(db, now) {
+  const stmt = db.prepare(`
+    INSERT OR IGNORE INTO roles (name, code, description, status, created_at, updated_at)
+    VALUES (@name, @code, @description, 'active', @created_at, @updated_at)
+  `);
+  for (const r of ROLES) {
+    stmt.run({ name: r.name, code: r.code, description: r.description, created_at: now, updated_at: now });
+  }
+}
+
+// ----- role_permissions -----
+function seedRolePermissions(db) {
+  const getRoleId = db.prepare(`SELECT id FROM roles WHERE code = ?`);
+  const getAllPermIds = db.prepare(`SELECT id FROM permissions`);
+  const getPermIdByCode = db.prepare(`SELECT id FROM permissions WHERE code = ?`);
+  const insertRP = db.prepare(`INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES (?, ?)`);
+
+  for (const role of ROLES) {
+    const roleRow = getRoleId.get(role.code);
+    if (!roleRow) continue;
+
+    let permIds;
+    if (role.permissions === "*") {
+      permIds = getAllPermIds.all().map((row) => row.id);
+    } else {
+      permIds = role.permissions
+        .map((code) => getPermIdByCode.get(code))
+        .filter(Boolean)
+        .map((row) => row.id);
+    }
+    for (const pid of permIds) {
+      insertRP.run(roleRow.id, pid);
+    }
+  }
+}
+
+// ----- super admin user -----
+function seedSuperAdmin(db, { adminEmail, adminPassword, adminPasswordHash, now }) {
+  const username = (adminEmail || "admin").split("@")[0] || "admin";
+  const existing = db
+    .prepare(`SELECT id FROM users WHERE email = ? OR username = ?`)
+    .get(adminEmail, username);
+
+  // 优先用 hash；否则现场 bcrypt（cost 10）
+  const passwordHash = adminPasswordHash && adminPasswordHash.trim().length > 0
+    ? adminPasswordHash
+    : bcrypt.hashSync(String(adminPassword || "admin"), 10);
+
+  let userId;
+  if (existing) {
+    userId = existing.id;
+    // 已存在则不覆盖密码；只确保是超管
+    db.prepare(`UPDATE users SET is_super_admin = 1, status = 'active', updated_at = ? WHERE id = ?`)
+      .run(now, userId);
+  } else {
+    const info = db.prepare(`
+      INSERT INTO users (username, email, password_hash, display_name, status, is_super_admin, created_at, updated_at)
+      VALUES (@username, @email, @password_hash, @display_name, 'active', 1, @created_at, @updated_at)
+    `).run({
+      username,
+      email: adminEmail,
+      password_hash: passwordHash,
+      display_name: "超级管理员",
+      created_at: now,
+      updated_at: now,
+    });
+    userId = info.lastInsertRowid;
+  }
+
+  // 绑定 super_admin 角色
+  const role = db.prepare(`SELECT id FROM roles WHERE code = 'super_admin'`).get();
+  if (role) {
+    db.prepare(`INSERT OR IGNORE INTO user_roles (user_id, role_id) VALUES (?, ?)`)
+      .run(userId, role.id);
+  }
+}
+
+// ----- menus -----
+// 策略：menus 表为空时才整树写入；非空说明用户已经在后台改过菜单，不动
+function seedMenus(db, now) {
+  const count = db.prepare(`SELECT COUNT(*) AS c FROM menus`).get().c;
+  if (count > 0) return;
+
+  const insert = db.prepare(`
+    INSERT INTO menus (parent_id, name, path, icon, permission_code, sort_order, status, created_at)
+    VALUES (@parent_id, @name, @path, @icon, @permission_code, @sort_order, 'active', @created_at)
+  `);
+
+  let order = 0;
+  for (const top of MENUS) {
+    order += 1;
+    const parentInfo = insert.run({
+      parent_id: null,
+      name: top.name,
+      path: top.path,
+      icon: top.icon,
+      permission_code: top.permission || null,
+      sort_order: top.sort != null ? top.sort : order,
+      created_at: now,
+    });
+    const parentId = parentInfo.lastInsertRowid;
+
+    if (Array.isArray(top.children)) {
+      let childOrder = 0;
+      for (const c of top.children) {
+        childOrder += 1;
+        insert.run({
+          parent_id: parentId,
+          name: c.name,
+          path: c.path,
+          icon: c.icon,
+          permission_code: c.permission || null,
+          sort_order: childOrder,
+          created_at: now,
+        });
+      }
+    }
+  }
+}
+
+module.exports = {
+  ensureRbacSeed,
+  // 单测时方便 import 内部常量
+  _PERMISSIONS: PERMISSIONS,
+  _ROLES: ROLES,
+  _MENUS: MENUS,
+};


### PR DESCRIPTION
Initialize 12 permissions, 3 default roles (super_admin / content_admin / viewer), bind role permissions, migrate super admin from .env (ADMIN_EMAIL/ADMIN_PASSWORD), seed 17-node default menu tree.

All seeds idempotent: INSERT OR IGNORE on UNIQUE codes, existence checks on user, empty-table guard on menus.

Add server/scripts/run-migrations.js to init DB without booting server. Add server/scripts/check-rbac-seed.js with 11 assertions for verification.

Closes #8
