### PR TITLE
feat(T1.6): scaffold adminApp.js

### DIFF
--- a/server/src/apps/adminApp.js
+++ b/server/src/apps/adminApp.js
@@ -1,0 +1,18 @@
+const express = require("express");
+
+const app = express();
+
+app.disable("x-powered-by");
+app.set("trust proxy", 1);
+
+app.use(express.json({ limit: "1mb" }));
+app.use(express.urlencoded({ extended: true, limit: "1mb" }));
+
+app.get("/health", (req, res) => {
+  res.json({ ok: true, service: "adminApp" });
+});
+
+const v2Router = express.Router();
+app.use("/api/v2", v2Router);
+
+module.exports = app;


### PR DESCRIPTION
## Summary

- New `server/src/apps/adminApp.js` — minimal Express instance for the v2 admin server (port 3000).
- Exposes `GET /health` → `{ ok: true, service: \"adminApp\" }` and an empty `/api/v2` router mount as a placeholder for forthcoming v2 business routes.
- Body parsers (`json` / `urlencoded`) wired up; helmet/CORS/JWT/RBAC are intentionally **not** included — those land in later tasks (T1.8 CORS, T2.x JWT/RBAC).
- Follows the apps/README contract: `module.exports = app` only, no `app.listen()`. Dual-port startup is wired into `index.js` in T1.7.

## Test plan

- [x] `node -c server/src/apps/adminApp.js` (syntax OK)
- [x] Boot smoke test on port 3000:
  ```
  $ node -e \"const app=require('./src/apps/adminApp'); app.listen(3000,()=>{...})\"
  listening on port 3000
  GET /health -> 200 {\"ok\":true,\"service\":\"adminApp\"}
  ```

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)