### PR TITLE
feat(T1.7): dual-port startup + shared DB connection

### DIFF
--- a/server/src/apps/frontApp.js
+++ b/server/src/apps/frontApp.js
@@ -9,15 +9,13 @@ const crypto = require("node:crypto");
 require("dotenv").config({ path: path.join(__dirname, "..", "..", ".env") });
 
 const { optional, required } = require("../env");
-const { openDb, migrate, ensureSeed, listTagsForPost, listTagsForPosts, listCategoriesForPosts, setPostTags, listCategoriesForPost, setPostCategories } = require("../db");
-const { ensureRbacSeed } = require("../seeds/rbacSeed");
+const { openDb, listTagsForPost, listTagsForPosts, listCategoriesForPosts, setPostTags, listCategoriesForPost, setPostCategories } = require("../db");
 const { renderMarkdownToSafeHtml } = require("../markdown");
 const { nowIso, normalizeSlug, splitTags, toInt } = require("../utils");
 const { verifyAdminLogin, requireAdmin, requireAdminPage } = require("../auth");
 
 const app = express();
 
-const PORT = toInt(optional("PORT", "8787"), 8787);
 const SESSION_SECRET = required("SESSION_SECRET", crypto.randomBytes(32).toString("hex"));
 const ADMIN_EMAIL = optional("ADMIN_EMAIL", "admin@example.com");
 const ADMIN_PASSWORD = optional("ADMIN_PASSWORD", "admin");
@@ -57,13 +55,6 @@ function safeUrl(s, { allowDataImage = false } = {}) {
 }
 
 const db = openDb();
-migrate(db);
-ensureSeed(db);
-ensureRbacSeed(db, {
-  adminEmail: ADMIN_EMAIL,
-  adminPassword: ADMIN_PASSWORD,
-  adminPasswordHash: ADMIN_PASSWORD_HASH,
-});
 
 const storage = multer.diskStorage({
   destination: (req, file, cb) => cb(null, UPLOAD_DIR),

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -3,13 +3,16 @@ const fs = require("node:fs");
 const Database = require("better-sqlite3");
 const { nowIso, normalizeSlug } = require("./utils");
 
+let _db = null;
+
 function openDb() {
+  if (_db) return _db;
   const dbPath = path.join(__dirname, "..", "db", "blog.sqlite");
   fs.mkdirSync(path.dirname(dbPath), { recursive: true });
-  const db = new Database(dbPath);
-  db.pragma("foreign_keys = ON");
-  db.pragma("journal_mode = WAL");
-  return db;
+  _db = new Database(dbPath);
+  _db.pragma("foreign_keys = ON");
+  _db.pragma("journal_mode = WAL");
+  return _db;
 }
 
 function migrate(db) {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,8 +1,31 @@
+const path = require("node:path");
+
+require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
+
+const { optional } = require("./env");
+const { openDb, migrate, ensureSeed } = require("./db");
+const { ensureRbacSeed } = require("./seeds/rbacSeed");
+
+const db = openDb();
+migrate(db);
+ensureSeed(db);
+ensureRbacSeed(db, {
+  adminEmail: optional("ADMIN_EMAIL", "admin@example.com"),
+  adminPassword: optional("ADMIN_PASSWORD", "admin"),
+  adminPasswordHash: optional("ADMIN_PASSWORD_HASH", ""),
+});
+
 const frontApp = require("./apps/frontApp");
+const adminApp = require("./apps/adminApp");
 
-const PORT = parseInt(process.env.PORT, 10) || 8787;
+const FRONT_PORT = parseInt(process.env.PORT, 10) || 8787;
+const ADMIN_PORT = parseInt(process.env.ADMIN_PORT, 10) || 3000;
 
-frontApp.listen(PORT, () => {
-  console.log(`Blog server running on http://localhost:${PORT}`);
-  console.log(`Admin: http://localhost:${PORT}/admin/login`);
+frontApp.listen(FRONT_PORT, () => {
+  console.log(`Front : http://localhost:${FRONT_PORT}`);
+  console.log(`Legacy admin (EJS) : http://localhost:${FRONT_PORT}/admin/login`);
+});
+
+adminApp.listen(ADMIN_PORT, () => {
+  console.log(`Admin v2 API : http://localhost:${ADMIN_PORT}/api/v2`);
 });


### PR DESCRIPTION
## Summary

- `index.js` now owns the boot sequence end-to-end:
  1. `dotenv.config(...)`
  2. `openDb()` → `migrate()` → `ensureSeed()` → `ensureRbacSeed()`
  3. `require("./apps/frontApp")` and `require("./apps/adminApp")`
  4. `frontApp.listen(8787)` + `adminApp.listen(3000)` (both ports overridable via `PORT` / `ADMIN_PORT` env)
- `db.js` — `openDb()` is now memoized, so subsequent require sites (frontApp, future adminApp DB usage, scripts) share the single SQLite connection inside one process.
- `frontApp.js` — drops its in-module DB init (`migrate` / `ensureSeed` / `ensureRbacSeed`) and the now-unused `PORT` const. Still grabs the connection via `openDb()` singleton, so all 30+ existing routes are unchanged.

## Test plan

Started `node src/index.js` once and probed both ports:

```
$ node src/index.js
Front : http://localhost:8787
Legacy admin (EJS) : http://localhost:8787/admin/login
Admin v2 API : http://localhost:3000/api/v2

GET 8787 /health        -> 200 {\"ok\":true}
GET 3000 /health        -> 200 {\"ok\":true,\"service\":\"adminApp\"}
GET 8787 /api/posts     -> 200 (6.3 KB)
GET 8787 /admin/login   -> 200 (EJS)
GET 8787 /rss.xml       -> 200
```

DB init runs exactly once at boot (no migration noise from frontApp's old in-module init).

## Notes for reviewer

- `dotenv.config()` is now called in both `index.js` (first thing) and `frontApp.js` (legacy line 9, kept as a safety net for standalone module loading). The second call is a no-op because dotenv won't override existing env vars.
- `frontApp.js` still reads `ADMIN_EMAIL` / `ADMIN_PASSWORD` / `ADMIN_PASSWORD_HASH` because `verifyAdminLogin` needs them on every login attempt — they are NOT only RBAC-seed concerns.
- Standalone scripts (`scripts/run-migrations.js`, `scripts/check-tables.js`, `scripts/check-rbac-seed.js`) keep working: they each open their own process and call `openDb()` once, so the singleton is benign.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)