### PR TITLE
feat(T1.8): dev-only CORS middleware for adminApp

### DIFF
--- a/server/src/apps/adminApp.js
+++ b/server/src/apps/adminApp.js
@@ -1,10 +1,12 @@
 const express = require("express");
+const devCors = require("../middleware/cors");
 
 const app = express();
 
 app.disable("x-powered-by");
 app.set("trust proxy", 1);
 
+app.use(devCors());
 app.use(express.json({ limit: "1mb" }));
 app.use(express.urlencoded({ extended: true, limit: "1mb" }));
 

--- a/server/src/middleware/cors.js
+++ b/server/src/middleware/cors.js
@@ -1,0 +1,15 @@
+const cors = require("cors");
+
+function devCors() {
+  if (process.env.NODE_ENV === "production") {
+    return (req, res, next) => next();
+  }
+  return cors({
+    origin: ["http://localhost:8787", "http://localhost:5173"],
+    credentials: true,
+    methods: ["GET", "POST", "PUT", "DELETE", "PATCH"],
+    allowedHeaders: ["Content-Type", "Authorization"],
+  });
+}
+
+module.exports = devCors;


### PR DESCRIPTION
## Summary

- New `server/src/middleware/cors.js` exports `devCors()`:
  - **Development** (`NODE_ENV !== 'production'`): returns `cors({ origin: [http://localhost:8787, http://localhost:5173], credentials: true, ... })`.
  - **Production**: returns a passthrough `(req, res, next) => next()` — Nginx will serve front + admin under the same domain, so no cross-origin headers are needed.
- `adminApp.js` mounts `devCors()` **before** body parsers so the OPTIONS preflight is answered before `express.json()` ever sees a request.

## Test plan

Both modes verified locally against `:3000/health`.

**Dev mode** (default `NODE_ENV`):
```
GET /health, Origin: http://localhost:5173
  -> 200, Access-Control-Allow-Origin: http://localhost:5173
       Access-Control-Allow-Credentials: true

OPTIONS /health, Origin: http://localhost:5173
  -> 204, Access-Control-Allow-Methods: GET,POST,PUT,DELETE,PATCH
       Access-Control-Allow-Headers: Content-Type,Authorization

GET /health, Origin: http://evil.example.com
  -> 200, no Access-Control-Allow-Origin (request still goes through;
     the browser's same-origin policy is what blocks the response)
```

**Production mode** (`NODE_ENV=production`):
```
GET /health, Origin: http://localhost:5173
  -> 200, no Access-Control-* headers

OPTIONS /health, Origin: http://localhost:5173
  -> 200 (Express default OPTIONS handler), no Access-Control-* headers
```

## Notes for reviewer

- The disallowed-origin GET still returns a 200 body — that is correct. CORS is enforced **by the browser**, not by the server. The server's job is only to NOT send `Access-Control-Allow-Origin` for unallowed origins; the browser then refuses to expose the response to the calling JS. curl bypasses this since it isn't a browser.
- Mount order on adminApp is now: `devCors() → express.json() → express.urlencoded()`. This matches the convention in `server/src/middleware/README.md` (`requestLogger → cors → jwtAuth → ...`); requestLogger / jwtAuth aren't built yet.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)