### PR TITLE
feat(T1.9): jwt auth middleware

### DIFF
--- a/server/scripts/check-jwt-auth.js
+++ b/server/scripts/check-jwt-auth.js
@@ -1,0 +1,107 @@
+// One-off helper: verify middleware/jwtAuth.js across 3 scenarios
+// Usage (from server/): node scripts/check-jwt-auth.js
+const jwt = require("jsonwebtoken");
+
+process.env.JWT_SECRET = "test-secret-for-jwtAuth-check-only-do-not-use-in-production";
+const jwtAuth = require("../src/middleware/jwtAuth");
+
+let pass = true;
+function check(label, ok, detail) {
+  const tag = ok ? "OK  " : "FAIL";
+  console.log(`[${tag}] ${label}${detail ? "  -- " + detail : ""}`);
+  if (!ok) pass = false;
+}
+
+function run(headers) {
+  const req = { headers };
+  let statusCode = 0;
+  let body = null;
+  let nextCalled = false;
+  const res = {
+    status(code) {
+      statusCode = code;
+      return this;
+    },
+    json(payload) {
+      body = payload;
+      return this;
+    },
+  };
+  jwtAuth(req, res, () => {
+    nextCalled = true;
+  });
+  return { req, statusCode, body, nextCalled };
+}
+
+const validPayload = {
+  userId: 1,
+  username: "admin",
+  roles: ["super_admin"],
+  type: "admin",
+};
+
+const validToken = jwt.sign(validPayload, process.env.JWT_SECRET, { expiresIn: "2h" });
+const expiredToken = jwt.sign(validPayload, process.env.JWT_SECRET, { expiresIn: "-1s" });
+
+// 1) no token
+{
+  const r = run({});
+  check("no token -> 401", r.statusCode === 401, `code=${r.body && r.body.code}`);
+  check("no token -> next NOT called", !r.nextCalled);
+}
+
+// 2) malformed Authorization header
+{
+  const r = run({ authorization: "Token abc" });
+  check("malformed header -> 401", r.statusCode === 401, `msg=${r.body && r.body.message}`);
+  check("malformed header -> next NOT called", !r.nextCalled);
+}
+
+// 3) expired token
+{
+  const r = run({ authorization: `Bearer ${expiredToken}` });
+  check("expired token -> 401", r.statusCode === 401);
+  check("expired token -> message says expired", r.body && r.body.message === "Token expired", `msg=${r.body && r.body.message}`);
+  check("expired token -> next NOT called", !r.nextCalled);
+}
+
+// 4) invalid signature
+{
+  const tampered = jwt.sign(validPayload, "wrong-secret", { expiresIn: "2h" });
+  const r = run({ authorization: `Bearer ${tampered}` });
+  check("invalid signature -> 401", r.statusCode === 401);
+  check("invalid signature -> message says invalid", r.body && r.body.message === "Invalid token");
+  check("invalid signature -> next NOT called", !r.nextCalled);
+}
+
+// 5) wrong type claim
+{
+  const wrongType = jwt.sign({ ...validPayload, type: "front" }, process.env.JWT_SECRET, { expiresIn: "2h" });
+  const r = run({ authorization: `Bearer ${wrongType}` });
+  check("wrong type -> 401", r.statusCode === 401);
+  check("wrong type -> message says invalid type", r.body && r.body.message === "Invalid token type");
+}
+
+// 6) valid token
+{
+  const r = run({ authorization: `Bearer ${validToken}` });
+  check("valid token -> next called", r.nextCalled);
+  check("valid token -> no status set", r.statusCode === 0);
+  check("valid token -> req.user.userId = 1", r.req.user && r.req.user.userId === 1);
+  check("valid token -> req.user.username = admin", r.req.user && r.req.user.username === "admin");
+  check("valid token -> req.user.roles = [super_admin]", r.req.user && Array.isArray(r.req.user.roles) && r.req.user.roles[0] === "super_admin");
+  check("valid token -> req.user.type = admin", r.req.user && r.req.user.type === "admin");
+}
+
+// 7) JWT_SECRET missing -> 500
+{
+  const saved = process.env.JWT_SECRET;
+  delete process.env.JWT_SECRET;
+  const r = run({ authorization: `Bearer ${validToken}` });
+  check("missing JWT_SECRET -> 500", r.statusCode === 500, `code=${r.body && r.body.code}`);
+  process.env.JWT_SECRET = saved;
+}
+
+console.log("");
+console.log(pass ? "PASS: jwtAuth verified across 3 scenarios (no token / expired / valid) plus edge cases." : "FAIL: see [FAIL] entries above.");
+process.exit(pass ? 0 : 1);

--- a/server/src/middleware/jwtAuth.js
+++ b/server/src/middleware/jwtAuth.js
@@ -1,0 +1,44 @@
+const jwt = require("jsonwebtoken");
+
+function jwtAuth(req, res, next) {
+  const header = req.headers["authorization"] || "";
+  const m = header.match(/^Bearer\s+(.+)$/i);
+  if (!m) {
+    return res.status(401).json({
+      code: 401,
+      message: "Missing or malformed Authorization header",
+    });
+  }
+
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    return res.status(500).json({
+      code: 500,
+      message: "Server JWT_SECRET not configured",
+    });
+  }
+
+  let payload;
+  try {
+    payload = jwt.verify(m[1], secret);
+  } catch (err) {
+    if (err.name === "TokenExpiredError") {
+      return res.status(401).json({ code: 401, message: "Token expired" });
+    }
+    return res.status(401).json({ code: 401, message: "Invalid token" });
+  }
+
+  if (payload.type !== "admin") {
+    return res.status(401).json({ code: 401, message: "Invalid token type" });
+  }
+
+  req.user = {
+    userId: payload.userId,
+    username: payload.username,
+    roles: Array.isArray(payload.roles) ? payload.roles : [],
+    type: payload.type,
+  };
+  next();
+}
+
+module.exports = jwtAuth;


### PR DESCRIPTION
## Summary

- 新建 \`server/src/middleware/jwtAuth.js\`：从 \`Authorization: Bearer\` 抽取 token，校验签名/过期/\`type === \"admin\"\`，将 \`{ userId, username, roles, type }\` 挂到 \`req.user\`。
- 失败统一返回 \`{ code, message }\` 格式（401 表示鉴权失败，500 表示 \`JWT_SECRET\` 未配置）。
- 新建 \`server/scripts/check-jwt-auth.js\`：覆盖 issue 三种验收场景（无 token / 过期 / 有效），外加格式异常、签名错、type 错、secret 缺失共 7 类。
- 未挂载到 adminApp —— 等 T1.11 (\`/api/v2/auth/login\`) 上线第一个受保护路由时再 \`use\`。
- 权限富化（roles → permissions 的 DB 查询）留给 T1.10 的 \`rbac.js\`，保持 jwtAuth 不依赖 DB。

Closes #13

## Test plan

- [x] \`node -c server/src/middleware/jwtAuth.js\` 语法通过
- [x] \`cd server && node scripts/check-jwt-auth.js\` 全部 19 项 OK，PASS 退出码 0
- [x] 三种主场景（无 token / 过期 / 有效）均按 issue 要求工作
- [x] 边界场景：malformed header → 401, invalid signature → 401, wrong type → 401, missing JWT_SECRET → 500
- [x] valid token → \`req.user.userId/username/roles/type\` 正确挂载，next() 调用，未设置 status

🤖 Generated with [Claude Code](https://claude.com/claude-code)