### PR TITLE
feat(T1.11): /api/v2/auth/login

### DIFF
--- a/server/scripts/check-auth-login.js
+++ b/server/scripts/check-auth-login.js
@@ -1,0 +1,138 @@
+// One-off helper: verify POST /api/v2/auth/login handler
+// Usage (from server/): node scripts/check-auth-login.js
+const path = require("node:path");
+require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
+
+if (!process.env.JWT_SECRET) {
+  process.env.JWT_SECRET = "test-secret-jwt-for-auth-login-check-do-not-use-in-prod";
+}
+
+const jwt = require("jsonwebtoken");
+const { openDb, migrate, ensureSeed } = require("../src/db");
+const { ensureRbacSeed } = require("../src/seeds/rbacSeed");
+
+const db = openDb();
+migrate(db);
+ensureSeed(db);
+ensureRbacSeed(db, {
+  adminEmail: process.env.ADMIN_EMAIL || "admin@example.com",
+  adminPassword: process.env.ADMIN_PASSWORD || "admin",
+  adminPasswordHash: process.env.ADMIN_PASSWORD_HASH || "",
+});
+
+const { login } = require("../src/apps/admin/auth/authHandlers");
+
+let pass = true;
+function check(label, ok, detail) {
+  const tag = ok ? "OK  " : "FAIL";
+  console.log(`[${tag}] ${label}${detail ? "  -- " + detail : ""}`);
+  if (!ok) pass = false;
+}
+
+async function call(body) {
+  const req = { body };
+  let statusCode = 0;
+  let respBody = null;
+  const res = {
+    status(c) { statusCode = c; return this; },
+    json(b) { respBody = b; return this; },
+  };
+  await login(req, res);
+  return { statusCode, body: respBody };
+}
+
+(async () => {
+  const adminEmail = process.env.ADMIN_EMAIL || "admin@example.com";
+  const adminPassword = process.env.ADMIN_PASSWORD || "admin";
+
+  // 1) correct credentials
+  let goodResp;
+  {
+    goodResp = await call({ email: adminEmail, password: adminPassword });
+    check("correct credentials -> 200", goodResp.statusCode === 200, `code=${goodResp.body && goodResp.body.code}`);
+    check("response.data.accessToken is string", goodResp.body && goodResp.body.data && typeof goodResp.body.data.accessToken === "string");
+    check("response.data.refreshToken is string", goodResp.body && goodResp.body.data && typeof goodResp.body.data.refreshToken === "string");
+    check("response.data.user.id > 0", goodResp.body && goodResp.body.data && goodResp.body.data.user && goodResp.body.data.user.id > 0);
+    check("response.data.user.email matches", goodResp.body && goodResp.body.data && goodResp.body.data.user.email === adminEmail);
+    check("response.data.user.isSuperAdmin === true", goodResp.body && goodResp.body.data && goodResp.body.data.user.isSuperAdmin === true);
+    check("response.data.user.roles is array", goodResp.body && goodResp.body.data && Array.isArray(goodResp.body.data.user.roles));
+    check("response.data.user has NO password_hash", goodResp.body && goodResp.body.data && !("password_hash" in goodResp.body.data.user));
+  }
+
+  // 2) wrong password
+  {
+    const r = await call({ email: adminEmail, password: "definitely-wrong-password" });
+    check("wrong password -> 401", r.statusCode === 401, `code=${r.body && r.body.code}`);
+  }
+
+  // 3) nonexistent email
+  {
+    const r = await call({ email: "ghost@example.com", password: "any" });
+    check("nonexistent email -> 401", r.statusCode === 401);
+  }
+
+  // 4) missing fields
+  {
+    const r = await call({ email: adminEmail });
+    check("missing password -> 400", r.statusCode === 400, `code=${r.body && r.body.code}`);
+  }
+  {
+    const r = await call({ password: adminPassword });
+    check("missing email -> 400", r.statusCode === 400);
+  }
+  {
+    const r = await call({});
+    check("empty body -> 400", r.statusCode === 400);
+  }
+  {
+    const r = await call(undefined);
+    check("undefined body -> 400", r.statusCode === 400);
+  }
+
+  // 5) tokens roundtrip via jwt.verify
+  if (goodResp && goodResp.statusCode === 200) {
+    try {
+      const decoded = jwt.verify(goodResp.body.data.accessToken, process.env.JWT_SECRET);
+      check("accessToken decodes successfully", true);
+      check("accessToken.type === 'admin'", decoded.type === "admin");
+      check("accessToken.userId > 0", decoded.userId > 0);
+      check("accessToken.username matches", decoded.username === goodResp.body.data.user.username);
+      check("accessToken.roles is array", Array.isArray(decoded.roles));
+      check("accessToken.exp present", typeof decoded.exp === "number");
+    } catch (err) {
+      check("accessToken decodes successfully", false, err.message);
+    }
+
+    try {
+      const decoded = jwt.verify(goodResp.body.data.refreshToken, process.env.JWT_SECRET);
+      check("refreshToken decodes successfully", true);
+      check("refreshToken.type === 'refresh'", decoded.type === "refresh");
+      check("refreshToken.userId > 0", decoded.userId > 0);
+    } catch (err) {
+      check("refreshToken decodes successfully", false, err.message);
+    }
+  }
+
+  // 6) disabled user is rejected
+  {
+    db.prepare("UPDATE users SET status = 'disabled' WHERE email = ?").run(adminEmail);
+    try {
+      const r = await call({ email: adminEmail, password: adminPassword });
+      check("disabled user -> 401", r.statusCode === 401);
+    } finally {
+      db.prepare("UPDATE users SET status = 'active' WHERE email = ?").run(adminEmail);
+    }
+  }
+
+  // 7) last_login_at updated after success
+  {
+    db.prepare("UPDATE users SET last_login_at = NULL WHERE email = ?").run(adminEmail);
+    await call({ email: adminEmail, password: adminPassword });
+    const u = db.prepare("SELECT last_login_at FROM users WHERE email = ?").get(adminEmail);
+    check("last_login_at updated after login", u && typeof u.last_login_at === "string" && u.last_login_at.length > 0);
+  }
+
+  console.log("");
+  console.log(pass ? "PASS: /api/v2/auth/login verified." : "FAIL: see [FAIL] entries above.");
+  process.exit(pass ? 0 : 1);
+})();

--- a/server/src/apps/admin/auth/authHandlers.js
+++ b/server/src/apps/admin/auth/authHandlers.js
@@ -1,0 +1,54 @@
+const { openDb } = require("../../../db");
+const { verifyV2Login, signV2AccessToken, signV2RefreshToken } = require("../../../auth");
+const { nowIso } = require("../../../utils");
+
+async function login(req, res) {
+  const { email, password } = req.body || {};
+  if (!email || !password) {
+    return res.status(400).json({ code: 400, message: "Missing email or password" });
+  }
+
+  const db = openDb();
+
+  let user;
+  try {
+    user = await verifyV2Login(db, { email, password });
+  } catch (err) {
+    return res.status(500).json({ code: 500, message: err.message });
+  }
+
+  if (!user) {
+    return res.status(401).json({ code: 401, message: "Invalid email or password" });
+  }
+
+  let accessToken;
+  let refreshToken;
+  try {
+    accessToken = signV2AccessToken(user);
+    refreshToken = signV2RefreshToken(user);
+  } catch (err) {
+    return res.status(500).json({ code: 500, message: err.message });
+  }
+
+  db.prepare("UPDATE users SET last_login_at = ? WHERE id = ?").run(nowIso(), user.id);
+
+  return res.status(200).json({
+    code: 200,
+    message: "success",
+    data: {
+      accessToken,
+      refreshToken,
+      user: {
+        id: user.id,
+        username: user.username,
+        email: user.email,
+        displayName: user.display_name || null,
+        avatarUrl: user.avatar_url || null,
+        isSuperAdmin: user.is_super_admin === 1,
+        roles: user.roles || [],
+      },
+    },
+  });
+}
+
+module.exports = { login };

--- a/server/src/apps/admin/auth/authRouter.js
+++ b/server/src/apps/admin/auth/authRouter.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const handlers = require("./authHandlers");
+
+const router = express.Router();
+
+router.post("/login", handlers.login);
+
+module.exports = router;

--- a/server/src/apps/adminApp.js
+++ b/server/src/apps/adminApp.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const devCors = require("../middleware/cors");
+const authRouter = require("./admin/auth/authRouter");
 
 const app = express();
 
@@ -15,6 +16,7 @@ app.get("/health", (req, res) => {
 });
 
 const v2Router = express.Router();
+v2Router.use("/auth", authRouter);
 app.use("/api/v2", v2Router);
 
 module.exports = app;

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -1,4 +1,5 @@
 const bcrypt = require("bcryptjs");
+const jwt = require("jsonwebtoken");
 
 function constantTimeEquals(a, b) {
   const sa = String(a ?? "");
@@ -25,9 +26,63 @@ function requireAdminPage(req, res, next) {
   return res.redirect("/admin/login");
 }
 
+async function verifyV2Login(db, { email, password }) {
+  if (!email || !password) return null;
+
+  const user = db
+    .prepare(
+      `SELECT id, username, email, password_hash, display_name, avatar_url,
+              status, is_super_admin
+         FROM users
+        WHERE email = ? AND status = 'active'`
+    )
+    .get(String(email));
+  if (!user) return null;
+
+  const ok = await bcrypt.compare(String(password), String(user.password_hash || ""));
+  if (!ok) return null;
+
+  const roles = db
+    .prepare(
+      `SELECT r.code FROM user_roles ur
+         JOIN roles r ON r.id = ur.role_id AND r.status = 'active'
+        WHERE ur.user_id = ?`
+    )
+    .all(user.id)
+    .map((row) => row.code);
+
+  return { ...user, roles };
+}
+
+function signV2AccessToken(user) {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) throw new Error("JWT_SECRET not configured");
+  const expiresIn = process.env.ADMIN_JWT_ACCESS_EXPIRES || "2h";
+  return jwt.sign(
+    {
+      userId: user.id,
+      username: user.username,
+      roles: Array.isArray(user.roles) ? user.roles : [],
+      type: "admin",
+    },
+    secret,
+    { expiresIn }
+  );
+}
+
+function signV2RefreshToken(user) {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) throw new Error("JWT_SECRET not configured");
+  const expiresIn = process.env.ADMIN_JWT_REFRESH_EXPIRES || "7d";
+  return jwt.sign({ userId: user.id, type: "refresh" }, secret, { expiresIn });
+}
+
 module.exports = {
   verifyAdminLogin,
   requireAdmin,
   requireAdminPage,
+  verifyV2Login,
+  signV2AccessToken,
+  signV2RefreshToken,
 };
 


### PR DESCRIPTION
## Summary
- 实现 `POST /api/v2/auth/login` — 邮箱+密码 → access/refresh JWT
- `auth.js` 新增 `verifyV2Login` / `signV2AccessToken` / `signV2RefreshToken`,旧 session 路径 (`verifyAdminLogin` / `requireAdmin*`) 不动
- `apps/admin/auth/{authHandlers,authRouter}.js` 拆分 controller / router
- `apps/adminApp.js` 挂载 `/api/v2/auth`
- bcrypt 校验 + 禁用用户拒绝 + 成功后更新 `last_login_at`
- 不暴露 `password_hash`,access token 含 `roles`,refresh token 仅含 `userId+type=refresh`

## Test plan
- [x] `node scripts/check-auth-login.js` — 25/25 通过
  - 正确凭据 → 200 + accessToken/refreshToken/user 形状正确
  - 错误密码 / 不存在邮箱 / 禁用用户 → 401
  - 缺字段 / 空 body / undefined body → 400
  - access token: `type='admin'`, `userId`, `username`, `roles`, `exp` 全部命中
  - refresh token: `type='refresh'`, `userId` 命中
  - `last_login_at` 登录后被更新
- [x] `node -c` 5 个文件语法 OK

Closes #15