### PR TITLE
feat(T1.12): /api/v2/auth/refresh

### DIFF
--- a/server/scripts/check-auth-refresh.js
+++ b/server/scripts/check-auth-refresh.js
@@ -1,0 +1,138 @@
+// One-off helper: verify POST /api/v2/auth/refresh handler
+// Usage (from server/): node scripts/check-auth-refresh.js
+const path = require("node:path");
+require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
+
+if (!process.env.JWT_SECRET) {
+  process.env.JWT_SECRET = "test-secret-jwt-for-auth-refresh-check-do-not-use-in-prod";
+}
+
+const jwt = require("jsonwebtoken");
+const { openDb, migrate, ensureSeed } = require("../src/db");
+const { ensureRbacSeed } = require("../src/seeds/rbacSeed");
+
+const db = openDb();
+migrate(db);
+ensureSeed(db);
+ensureRbacSeed(db, {
+  adminEmail: process.env.ADMIN_EMAIL || "admin@example.com",
+  adminPassword: process.env.ADMIN_PASSWORD || "admin",
+  adminPasswordHash: process.env.ADMIN_PASSWORD_HASH || "",
+});
+
+const { login, refresh } = require("../src/apps/admin/auth/authHandlers");
+
+let pass = true;
+function check(label, ok, detail) {
+  const tag = ok ? "OK  " : "FAIL";
+  console.log(`[${tag}] ${label}${detail ? "  -- " + detail : ""}`);
+  if (!ok) pass = false;
+}
+
+async function call(handler, body) {
+  const req = { body };
+  let statusCode = 0;
+  let respBody = null;
+  const res = {
+    status(c) { statusCode = c; return this; },
+    json(b) { respBody = b; return this; },
+  };
+  await handler(req, res);
+  return { statusCode, body: respBody };
+}
+
+(async () => {
+  const adminEmail = process.env.ADMIN_EMAIL || "admin@example.com";
+  const adminPassword = process.env.ADMIN_PASSWORD || "admin";
+
+  // 0) login to obtain a real refreshToken
+  const loginResp = await call(login, { email: adminEmail, password: adminPassword });
+  check("login returned 200", loginResp.statusCode === 200);
+  const refreshToken = loginResp.body && loginResp.body.data && loginResp.body.data.refreshToken;
+  const oldAccessToken = loginResp.body && loginResp.body.data && loginResp.body.data.accessToken;
+  check("login provided refreshToken", typeof refreshToken === "string" && refreshToken.length > 0);
+  // 1) refresh with valid refreshToken
+  let refreshResp;
+  {
+    refreshResp = await call(refresh, { refreshToken });
+    check("valid refresh -> 200", refreshResp.statusCode === 200, `code=${refreshResp.body && refreshResp.body.code}`);
+    check("response.data.accessToken is string", refreshResp.body && refreshResp.body.data && typeof refreshResp.body.data.accessToken === "string");
+    check("response.data has NO refreshToken", refreshResp.body && refreshResp.body.data && !("refreshToken" in refreshResp.body.data));
+  }
+
+  // 2) verify new accessToken payload
+  if (refreshResp && refreshResp.statusCode === 200) {
+    try {
+      const decoded = jwt.verify(refreshResp.body.data.accessToken, process.env.JWT_SECRET);
+      check("new accessToken.type === 'admin'", decoded.type === "admin");
+      check("new accessToken.userId > 0", decoded.userId > 0);
+      check("new accessToken.username present", typeof decoded.username === "string");
+      check("new accessToken.roles is array", Array.isArray(decoded.roles));
+      check("new accessToken.exp present", typeof decoded.exp === "number");
+    } catch (err) {
+      check("new accessToken decodes successfully", false, err.message);
+    }
+  }
+
+  // 3) missing refreshToken / empty body / undefined body -> 400
+  {
+    const r = await call(refresh, {});
+    check("empty body -> 400", r.statusCode === 400, `code=${r.body && r.body.code}`);
+  }
+  {
+    const r = await call(refresh, undefined);
+    check("undefined body -> 400", r.statusCode === 400);
+  }
+  {
+    const r = await call(refresh, { refreshToken: "" });
+    check("empty refreshToken string -> 400", r.statusCode === 400);
+  }
+
+  // 4) malformed token -> 401
+  {
+    const r = await call(refresh, { refreshToken: "not.a.valid.jwt" });
+    check("malformed token -> 401", r.statusCode === 401, `code=${r.body && r.body.code}`);
+  }
+
+  // 5) access token (wrong type='admin') -> 401
+  {
+    const r = await call(refresh, { refreshToken: oldAccessToken });
+    check("access token used as refresh -> 401", r.statusCode === 401);
+  }
+
+  // 6) token signed with wrong secret -> 401
+  {
+    const fake = jwt.sign({ userId: 1, type: "refresh" }, "wrong-secret-not-the-real-one", { expiresIn: "1h" });
+    const r = await call(refresh, { refreshToken: fake });
+    check("token signed with wrong secret -> 401", r.statusCode === 401);
+  }
+
+  // 7) expired refresh token -> 401 with "expired" message
+  {
+    const expired = jwt.sign({ userId: 1, type: "refresh" }, process.env.JWT_SECRET, { expiresIn: "-1s" });
+    const r = await call(refresh, { refreshToken: expired });
+    check("expired refresh -> 401", r.statusCode === 401, `code=${r.body && r.body.code}`);
+    check("expired refresh message mentions 'expired'", r.body && /expired/i.test(r.body.message));
+  }
+
+  // 8) disabled user -> 401
+  {
+    db.prepare("UPDATE users SET status = 'disabled' WHERE email = ?").run(adminEmail);
+    try {
+      const r = await call(refresh, { refreshToken });
+      check("disabled user refresh -> 401", r.statusCode === 401);
+    } finally {
+      db.prepare("UPDATE users SET status = 'active' WHERE email = ?").run(adminEmail);
+    }
+  }
+
+  // 9) after re-enabling, refresh works again
+  {
+    const r = await call(refresh, { refreshToken });
+    check("re-enabled user refresh -> 200", r.statusCode === 200);
+  }
+
+  console.log("");
+  console.log(pass ? "PASS: /api/v2/auth/refresh verified." : "FAIL: see [FAIL] entries above.");
+  process.exit(pass ? 0 : 1);
+})();

--- a/server/src/apps/admin/auth/authHandlers.js
+++ b/server/src/apps/admin/auth/authHandlers.js
@@ -1,5 +1,10 @@
 const { openDb } = require("../../../db");
-const { verifyV2Login, signV2AccessToken, signV2RefreshToken } = require("../../../auth");
+const {
+  verifyV2Login,
+  signV2AccessToken,
+  signV2RefreshToken,
+  verifyV2Refresh,
+} = require("../../../auth");
 const { nowIso } = require("../../../utils");
 
 async function login(req, res) {
@@ -51,4 +56,43 @@ async function login(req, res) {
   });
 }
 
-module.exports = { login };
+async function refresh(req, res) {
+  const { refreshToken } = req.body || {};
+  if (!refreshToken) {
+    return res.status(400).json({ code: 400, message: "Missing refreshToken" });
+  }
+
+  const db = openDb();
+
+  let result;
+  try {
+    result = verifyV2Refresh(db, refreshToken);
+  } catch (err) {
+    return res.status(500).json({ code: 500, message: err.message });
+  }
+
+  if (!result.ok) {
+    const message =
+      result.code === "expired"
+        ? "Refresh token expired"
+        : result.code === "user_disabled"
+        ? "User not found or disabled"
+        : "Invalid refresh token";
+    return res.status(401).json({ code: 401, message });
+  }
+
+  let accessToken;
+  try {
+    accessToken = signV2AccessToken(result.user);
+  } catch (err) {
+    return res.status(500).json({ code: 500, message: err.message });
+  }
+
+  return res.status(200).json({
+    code: 200,
+    message: "success",
+    data: { accessToken },
+  });
+}
+
+module.exports = { login, refresh };

--- a/server/src/apps/admin/auth/authRouter.js
+++ b/server/src/apps/admin/auth/authRouter.js
@@ -4,5 +4,6 @@ const handlers = require("./authHandlers");
 const router = express.Router();
 
 router.post("/login", handlers.login);
+router.post("/refresh", handlers.refresh);
 
 module.exports = router;

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -77,6 +77,43 @@ function signV2RefreshToken(user) {
   return jwt.sign({ userId: user.id, type: "refresh" }, secret, { expiresIn });
 }
 
+function verifyV2Refresh(db, refreshToken) {
+  if (!refreshToken) return { ok: false, code: "missing" };
+  const secret = process.env.JWT_SECRET;
+  if (!secret) throw new Error("JWT_SECRET not configured");
+
+  let payload;
+  try {
+    payload = jwt.verify(String(refreshToken), secret);
+  } catch (err) {
+    if (err.name === "TokenExpiredError") return { ok: false, code: "expired" };
+    return { ok: false, code: "invalid" };
+  }
+  if (payload.type !== "refresh") return { ok: false, code: "wrong_type" };
+  if (!payload.userId) return { ok: false, code: "invalid" };
+
+  const user = db
+    .prepare(
+      `SELECT id, username, email, display_name, avatar_url,
+              status, is_super_admin
+         FROM users
+        WHERE id = ? AND status = 'active'`
+    )
+    .get(payload.userId);
+  if (!user) return { ok: false, code: "user_disabled" };
+
+  const roles = db
+    .prepare(
+      `SELECT r.code FROM user_roles ur
+         JOIN roles r ON r.id = ur.role_id AND r.status = 'active'
+        WHERE ur.user_id = ?`
+    )
+    .all(user.id)
+    .map((row) => row.code);
+
+  return { ok: true, user: { ...user, roles } };
+}
+
 module.exports = {
   verifyAdminLogin,
   requireAdmin,
@@ -84,5 +121,6 @@ module.exports = {
   verifyV2Login,
   signV2AccessToken,
   signV2RefreshToken,
+  verifyV2Refresh,
 };
 


### PR DESCRIPTION
## Summary
- 实现 `POST /api/v2/auth/refresh` — 用 refresh token 续 access
- `auth.js` 新增 `verifyV2Refresh(db, token)`：验签 + 校验 `type==='refresh'` + 按 userId 重新拉用户和当前激活角色 → 返回 `{ ok, code, user }` 标签结果
- `authHandlers.js` 新增 `refresh` handler:
  - 缺 / 空 token → 400
  - 过期 / 无效签名 / 错类型(用 access 当 refresh) / 用户已禁用 → 401（错误信息按场景分别给）
  - 通过则用最新 user+roles 重新签发 accessToken,不下发新 refreshToken
- `authRouter.js` 挂 `POST /refresh`

> 不下发新 refresh token —— 滚动 / 黑名单逻辑放到 T1.13 logout 一起做

## Test plan
- [x] `node scripts/check-auth-refresh.js` — 20/20 通过
  - 登录后 refresh → 200 + 新 accessToken(`type=admin`,`userId`,`username`,`roles`,`exp`)
  - 不下发 refreshToken
  - 缺字段 / 空 body / 空 token 字符串 → 400
  - 乱码 token / 错密钥签的 token / 用 access token / 过期 token → 401(过期 message 含 'expired')
  - 用户被 disable 时 refresh → 401,re-enable 后 → 200

Closes #16