### PR TITLE
feat(T1.16): vite dev proxy /api -> :3000

### DIFF
--- a/admin/scripts/check-vite-proxy.mjs
+++ b/admin/scripts/check-vite-proxy.mjs
@@ -1,0 +1,71 @@
+// One-off helper: verify admin/vite.config.ts has /api proxy to :3000
+// Usage (from admin/): node scripts/check-vite-proxy.mjs
+import { loadConfigFromFile } from 'vite'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const root = path.join(__dirname, '..')
+const configPath = path.join(root, 'vite.config.ts')
+
+const result = await loadConfigFromFile(
+  { command: 'serve', mode: 'development' },
+  configPath,
+)
+if (!result) {
+  console.error('FAIL: could not load vite.config.ts')
+  process.exit(1)
+}
+
+const cfg = result.config
+const proxy = cfg.server?.proxy ?? {}
+
+let pass = true
+function check(label, ok, detail) {
+  const tag = ok ? 'OK  ' : 'FAIL'
+  console.log(`[${tag}] ${label}${detail ? '  -- ' + detail : ''}`)
+  if (!ok) pass = false
+}
+
+check('server.proxy is an object', typeof proxy === 'object' && proxy !== null)
+check('proxy["/api"] is configured', '/api' in proxy)
+
+const apiCfg = proxy['/api']
+const target =
+  typeof apiCfg === 'string' ? apiCfg : apiCfg?.target
+check(
+  'proxy["/api"].target === http://localhost:3000',
+  target === 'http://localhost:3000',
+  `got: ${target}`,
+)
+
+const changeOrigin =
+  typeof apiCfg === 'object' && apiCfg !== null
+    ? apiCfg.changeOrigin
+    : undefined
+check(
+  'proxy["/api"].changeOrigin === true',
+  changeOrigin === true,
+  `got: ${changeOrigin}`,
+)
+
+// sanity: the dev server still binds to 5173 (T1.14 contract)
+check(
+  'server.port === 5173',
+  cfg.server?.port === 5173,
+  `got: ${cfg.server?.port}`,
+)
+check(
+  'server.strictPort === true',
+  cfg.server?.strictPort === true,
+  `got: ${cfg.server?.strictPort}`,
+)
+
+console.log('')
+console.log(
+  pass
+    ? 'PASS: /api -> http://localhost:3000 proxy is configured.'
+    : 'FAIL: see [FAIL] entries above.',
+)
+process.exit(pass ? 0 : 1)

--- a/admin/vite.config.ts
+++ b/admin/vite.config.ts
@@ -8,5 +8,13 @@ export default defineConfig({
   server: {
     port: 5173,
     strictPort: true,
+    proxy: {
+      // Forward all /api/* requests to the adminApp (Express @ :3000).
+      // The path is preserved (/api/v2/auth/login -> :3000/api/v2/auth/login).
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary

Wires `admin/` (Vite dev server @ 5173) to the v2 admin API (`adminApp` @ 3000) by proxying `/api/*`, so the SPA can call `fetch('/api/v2/auth/login')` during development without CORS or hardcoded hosts.

Closes #20

## Changes

| File | What |
|------|------|
| [admin/vite.config.ts](admin/vite.config.ts) | Added `server.proxy['/api']: { target: 'http://localhost:3000', changeOrigin: true }` |
| [admin/scripts/check-vite-proxy.mjs](admin/scripts/check-vite-proxy.mjs) | New static config-shape verifier (6 assertions) |

## Design notes

- **`changeOrigin: true`** — rewrites the `Host` header to `localhost:3000` so when adminApp later adds Host-based logic (e.g. CORS allowlist via `req.headers.host`), the proxied request looks like a direct hit.
- **Path is preserved** — `/api/v2/auth/login` on the SPA → `:3000/api/v2/auth/login` on adminApp. No `rewrite` rule, since the v2 router is already mounted under `/api/v2/*`.
- **`port: 5173` + `strictPort: true`** kept from T1.14 — the dev contract is fixed.
- **Verification is static, not E2E**. We use Vite's `loadConfigFromFile` to read the resolved config object and assert shape. Booting both adminApp@3000 and vite@5173 + curling through the proxy would only re-verify Vite's own proxy implementation, which is upstream-tested.

## Verification

```bash
$ cd admin && node scripts/check-vite-proxy.mjs
[OK  ] server.proxy is an object
[OK  ] proxy["/api"] is configured
[OK  ] proxy["/api"].target === http://localhost:3000
[OK  ] proxy["/api"].changeOrigin === true
[OK  ] server.port === 5173
[OK  ] server.strictPort === true
PASS: /api -> http://localhost:3000 proxy is configured.
```

Build smoke (`npm run build`) still passes — 4136 modules, ~820ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)