### PR TITLE
feat(T1.18): pinia auth store with localStorage persistence

### DIFF
--- a/admin/scripts/check-auth-store.ts
+++ b/admin/scripts/check-auth-store.ts
@@ -1,0 +1,413 @@
+// Verifies the behavior of admin/src/stores/auth.ts:
+// - login() persists tokens + user to localStorage and updates reactive refs
+// - reload (fresh pinia / fresh store instance) rehydrates from localStorage
+// - fetchMe() updates the user from /api/v2/auth/me
+// - logout() clears local state and survives a server-side failure
+// - reset() clears state without a server call
+// - syncFromStorage() refreshes refs after the axios interceptor silently
+//   rotates the access token in tokenStorage
+// - login with bad creds throws and leaves the prior state untouched
+//
+// localStorage is polyfilled in-process; pinia is set up via
+// setActivePinia(createPinia()). Each scenario runs against a real
+// node:http mock and uses a createRequest({...}) client built against
+// that mock (so we exercise the real axios interceptors / type wrappers
+// rather than stubbing fetch).
+//
+// Usage (from admin/):
+//   npx tsx scripts/check-auth-store.ts
+
+import http from 'node:http'
+
+class MemoryStorage {
+  private data = new Map<string, string>()
+  get length(): number {
+    return this.data.size
+  }
+  key(i: number): string | null {
+    return Array.from(this.data.keys())[i] ?? null
+  }
+  getItem(k: string): string | null {
+    return this.data.get(k) ?? null
+  }
+  setItem(k: string, v: string): void {
+    this.data.set(k, String(v))
+  }
+  removeItem(k: string): void {
+    this.data.delete(k)
+  }
+  clear(): void {
+    this.data.clear()
+  }
+}
+
+;(globalThis as unknown as { localStorage: MemoryStorage }).localStorage =
+  new MemoryStorage()
+
+// Imports come AFTER the polyfill so any module-load-time side effect that
+// references localStorage finds the shim. (None currently do — token store
+// closures read localStorage lazily — but imports are hoisted in ESM, so
+// even if we add eager reads later this ordering keeps working.)
+const { createPinia, setActivePinia } = await import('pinia')
+const { createRequest } = await import('../src/api/request')
+const { createMemoryTokenStore } = await import('../src/api/tokenStorage')
+const { useAuthStore } = await import('../src/stores/auth')
+
+const PORT = 33425
+const BASE = `http://localhost:${PORT}`
+
+interface MockState {
+  loginShouldFail: boolean
+  logoutShouldFail: boolean
+  meReturnsUserId: number
+  loginHits: number
+  logoutHits: number
+  meHits: number
+}
+
+function newMockState(): MockState {
+  return {
+    loginShouldFail: false,
+    logoutShouldFail: false,
+    meReturnsUserId: 7,
+    loginHits: 0,
+    logoutHits: 0,
+    meHits: 0,
+  }
+}
+
+let mock: MockState = newMockState()
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    let body = ''
+    req.on('data', (c) => {
+      body += c
+    })
+    req.on('end', () => resolve(body))
+  })
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = req.url || ''
+  res.setHeader('Content-Type', 'application/json')
+
+  if (url === '/api/v2/auth/login' && req.method === 'POST') {
+    mock.loginHits++
+    const body = await readBody(req)
+    if (mock.loginShouldFail) {
+      res.statusCode = 401
+      res.end(
+        JSON.stringify({ code: 401, message: 'Invalid email or password' }),
+      )
+      return
+    }
+    const parsed = JSON.parse(body) as { email?: string }
+    res.statusCode = 200
+    res.end(
+      JSON.stringify({
+        code: 200,
+        message: 'success',
+        data: {
+          accessToken: 'access-from-login',
+          refreshToken: 'refresh-from-login',
+          user: {
+            id: 7,
+            username: 'tester',
+            email: parsed.email ?? 'tester@example.com',
+            displayName: 'Tester',
+            avatarUrl: null,
+            isSuperAdmin: false,
+            roles: ['editor'],
+          },
+        },
+      }),
+    )
+    return
+  }
+
+  if (url === '/api/v2/auth/logout' && req.method === 'POST') {
+    mock.logoutHits++
+    if (mock.logoutShouldFail) {
+      res.statusCode = 500
+      res.end(JSON.stringify({ code: 500, message: 'oops' }))
+      return
+    }
+    res.statusCode = 200
+    res.end(
+      JSON.stringify({
+        code: 200,
+        message: 'success',
+        data: { loggedOut: true },
+      }),
+    )
+    return
+  }
+
+  if (url === '/api/v2/auth/me' && req.method === 'GET') {
+    mock.meHits++
+    res.statusCode = 200
+    res.end(
+      JSON.stringify({
+        code: 200,
+        message: 'success',
+        data: {
+          id: mock.meReturnsUserId,
+          username: 'tester',
+          email: 'tester@example.com',
+          displayName: 'Tester (me)',
+          avatarUrl: 'https://example.com/avatar.png',
+          isSuperAdmin: false,
+          lastLoginAt: '2026-05-03T00:00:00.000Z',
+          createdAt: '2026-04-01T00:00:00.000Z',
+          roles: [
+            { id: 2, code: 'editor', name: 'Editor' },
+            { id: 3, code: 'viewer', name: 'Viewer' },
+          ],
+          permissions: ['post:list', 'post:create'],
+        },
+      }),
+    )
+    return
+  }
+
+  res.statusCode = 404
+  res.end(JSON.stringify({ code: 404, message: 'not found' }))
+})
+
+let pass = true
+function check(label: string, ok: boolean, detail?: string) {
+  const tag = ok ? 'OK  ' : 'FAIL'
+  console.log(`[${tag}] ${label}${detail ? '  -- ' + detail : ''}`)
+  if (!ok) pass = false
+}
+
+function freshAppState() {
+  setActivePinia(createPinia())
+  ;(globalThis as unknown as { localStorage: MemoryStorage }).localStorage =
+    new MemoryStorage()
+}
+
+function makeClient() {
+  return createRequest({
+    baseURL: BASE,
+    tokenStore: createMemoryTokenStore(),
+    onUnauthorized: () => {},
+  })
+}
+
+async function run() {
+  await new Promise<void>((resolve) => server.listen(PORT, resolve))
+
+  try {
+    // === L: login persists everything ===
+    {
+      mock = newMockState()
+      freshAppState()
+      const auth = useAuthStore()
+      check('L0: starts unauthenticated', auth.isAuthenticated === false)
+      const client = makeClient()
+      const u = await auth.login('tester@example.com', 'pw', client)
+      check('L1: login returned the user', u.id === 7 && u.email === 'tester@example.com')
+      check('L2: accessToken in store', auth.accessToken === 'access-from-login')
+      check('L3: refreshToken in store', auth.refreshToken === 'refresh-from-login')
+      check('L4: user.id === 7', auth.user?.id === 7)
+      check('L5: user.roles === ["editor"]', JSON.stringify(auth.user?.roles) === '["editor"]')
+      check('L6: isAuthenticated', auth.isAuthenticated === true)
+      check(
+        'L7: localStorage.admin.access_token persisted',
+        localStorage.getItem('admin.access_token') === 'access-from-login',
+      )
+      check(
+        'L8: localStorage.admin.refresh_token persisted',
+        localStorage.getItem('admin.refresh_token') === 'refresh-from-login',
+      )
+      const userJson = localStorage.getItem('admin.user')
+      check('L9: localStorage.admin.user persisted', !!userJson)
+      const persistedUser = userJson ? JSON.parse(userJson) : null
+      check(
+        'L10: persisted user.email matches',
+        persistedUser?.email === 'tester@example.com',
+      )
+      check('L11: server hit once', mock.loginHits === 1)
+    }
+
+    // === R: reload — fresh pinia, fresh store, hydrates from localStorage ===
+    {
+      // Use the localStorage state from the previous scenario to simulate reload.
+      // Save the current LS into a fresh app state.
+      const accessTokenBefore = localStorage.getItem('admin.access_token')
+      const refreshTokenBefore = localStorage.getItem('admin.refresh_token')
+      const userJsonBefore = localStorage.getItem('admin.user')
+
+      setActivePinia(createPinia())
+      // Don't reset localStorage — that's the point: reload preserves it.
+      // (However we DO need a clean Pinia instance.)
+
+      const auth2 = useAuthStore()
+      check('R1: hydrated accessToken', auth2.accessToken === accessTokenBefore)
+      check('R2: hydrated refreshToken', auth2.refreshToken === refreshTokenBefore)
+      check('R3: hydrated user.id', auth2.user?.id === 7)
+      check(
+        'R4: hydrated user.email',
+        auth2.user?.email === JSON.parse(userJsonBefore!).email,
+      )
+      check('R5: isAuthenticated after reload', auth2.isAuthenticated === true)
+    }
+
+    // === M: fetchMe overwrites user with richer me data ===
+    {
+      mock = newMockState()
+      freshAppState()
+      const auth = useAuthStore()
+      const client = makeClient()
+      await auth.login('tester@example.com', 'pw', client)
+      const meUser = await auth.fetchMe(client)
+      check('M1: fetchMe returns user', meUser.id === 7)
+      check('M2: displayName from /me', auth.user?.displayName === 'Tester (me)')
+      check(
+        'M3: avatarUrl from /me',
+        auth.user?.avatarUrl === 'https://example.com/avatar.png',
+      )
+      check(
+        'M4: roles flattened to codes',
+        JSON.stringify(auth.user?.roles) === '["editor","viewer"]',
+      )
+      const persisted = localStorage.getItem('admin.user')
+      const parsed = persisted ? JSON.parse(persisted) : null
+      check(
+        'M5: persisted displayName updated',
+        parsed?.displayName === 'Tester (me)',
+      )
+      check('M6: /me hit once', mock.meHits === 1)
+    }
+
+    // === O: logout clears state, server hit ===
+    {
+      mock = newMockState()
+      freshAppState()
+      const auth = useAuthStore()
+      const client = makeClient()
+      await auth.login('tester@example.com', 'pw', client)
+      check('O0: pre-logout authenticated', auth.isAuthenticated === true)
+      await auth.logout(client)
+      check('O1: accessToken cleared', auth.accessToken === null)
+      check('O2: refreshToken cleared', auth.refreshToken === null)
+      check('O3: user null', auth.user === null)
+      check('O4: isAuthenticated false', auth.isAuthenticated === false)
+      check(
+        'O5: localStorage.admin.access_token cleared',
+        localStorage.getItem('admin.access_token') === null,
+      )
+      check(
+        'O6: localStorage.admin.refresh_token cleared',
+        localStorage.getItem('admin.refresh_token') === null,
+      )
+      check(
+        'O7: localStorage.admin.user cleared',
+        localStorage.getItem('admin.user') === null,
+      )
+      check('O8: /logout hit once', mock.logoutHits === 1)
+    }
+
+    // === F: logout still clears local state when server fails ===
+    {
+      mock = newMockState()
+      mock.logoutShouldFail = true
+      freshAppState()
+      const auth = useAuthStore()
+      const client = makeClient()
+      await auth.login('tester@example.com', 'pw', client)
+      await auth.logout(client) // should NOT throw
+      check('F1: accessToken cleared after server failure', auth.accessToken === null)
+      check('F2: user null after server failure', auth.user === null)
+      check('F3: /logout hit was attempted', mock.logoutHits === 1)
+      check(
+        'F4: localStorage cleared after server failure',
+        localStorage.getItem('admin.access_token') === null &&
+          localStorage.getItem('admin.user') === null,
+      )
+    }
+
+    // === X: reset() clears without server call ===
+    {
+      mock = newMockState()
+      freshAppState()
+      const auth = useAuthStore()
+      const client = makeClient()
+      await auth.login('tester@example.com', 'pw', client)
+      const logoutHitsBefore = mock.logoutHits
+      auth.reset()
+      check('X1: accessToken cleared by reset', auth.accessToken === null)
+      check('X2: user null after reset', auth.user === null)
+      check('X3: /logout NOT hit by reset', mock.logoutHits === logoutHitsBefore)
+      check(
+        'X4: localStorage cleared by reset',
+        localStorage.getItem('admin.access_token') === null,
+      )
+    }
+
+    // === S: syncFromStorage picks up an out-of-band token rotation ===
+    {
+      mock = newMockState()
+      freshAppState()
+      const auth = useAuthStore()
+      const client = makeClient()
+      await auth.login('tester@example.com', 'pw', client)
+      // Simulate the axios interceptor silently refreshing the token: the
+      // shared tokenStorage gets updated, but the auth store's reactive
+      // ref hasn't been told yet.
+      localStorage.setItem('admin.access_token', 'rotated-by-interceptor')
+      check(
+        'S0: ref still holds old value before sync',
+        auth.accessToken === 'access-from-login',
+      )
+      auth.syncFromStorage()
+      check(
+        'S1: ref reflects rotated value after sync',
+        auth.accessToken === 'rotated-by-interceptor',
+      )
+    }
+
+    // === A: bad creds — login throws, prior state untouched ===
+    {
+      mock = newMockState()
+      freshAppState()
+      const auth = useAuthStore()
+      const client = makeClient()
+      // First login successfully
+      await auth.login('tester@example.com', 'pw', client)
+      check('A0: pre-bad login authenticated', auth.isAuthenticated === true)
+      // Now flip the mock to fail and try again
+      mock.loginShouldFail = true
+      let threw = false
+      try {
+        await auth.login('tester@example.com', 'wrong-pw', client)
+      } catch {
+        threw = true
+      }
+      check('A1: bad login throws', threw)
+      check(
+        'A2: prior accessToken preserved',
+        auth.accessToken === 'access-from-login',
+      )
+      check('A3: prior user preserved', auth.user?.id === 7)
+      check('A4: still authenticated', auth.isAuthenticated === true)
+    }
+  } finally {
+    server.close()
+  }
+
+  console.log('')
+  console.log(
+    pass
+      ? 'PASS: auth store behavior verified.'
+      : 'FAIL: see [FAIL] entries above.',
+  )
+  process.exit(pass ? 0 : 1)
+}
+
+run().catch((err) => {
+  console.error('UNEXPECTED ERROR:', err)
+  process.exit(1)
+})

--- a/admin/src/api/auth.ts
+++ b/admin/src/api/auth.ts
@@ -1,0 +1,82 @@
+// Typed wrappers around the v2 admin auth endpoints. Built on the shared
+// `request` axios instance from ./request.ts so they pick up the Bearer
+// header + 401 auto-refresh interceptor.
+
+import { request, type ApiResponse } from './request'
+import type { AxiosInstance } from 'axios'
+
+export interface UserInfo {
+  id: number
+  username: string
+  email: string
+  displayName: string | null
+  avatarUrl: string | null
+  isSuperAdmin: boolean
+  roles: string[]
+}
+
+export interface LoginResponseData {
+  accessToken: string
+  refreshToken: string
+  user: UserInfo
+}
+
+export interface MeResponseData {
+  id: number
+  username: string
+  email: string
+  displayName: string | null
+  avatarUrl: string | null
+  isSuperAdmin: boolean
+  lastLoginAt: string | null
+  createdAt: string
+  roles: Array<{ id: number; code: string; name: string }>
+  permissions: string[]
+}
+
+export interface MenuNode {
+  id: number
+  parent_id: number | null
+  name: string
+  path: string | null
+  icon: string | null
+  permission_code: string | null
+  sort_order: number
+  children: MenuNode[]
+}
+
+// Each call accepts an optional axios instance so tests can pass a
+// mock-server-bound client built via createRequest({...}).
+export async function apiLogin(
+  email: string,
+  password: string,
+  client: AxiosInstance = request,
+): Promise<LoginResponseData> {
+  const res = await client.post<ApiResponse<LoginResponseData>>(
+    '/api/v2/auth/login',
+    { email, password },
+  )
+  return res.data.data
+}
+
+export async function apiLogout(
+  client: AxiosInstance = request,
+): Promise<void> {
+  await client.post<ApiResponse<{ loggedOut: boolean }>>('/api/v2/auth/logout')
+}
+
+export async function apiMe(
+  client: AxiosInstance = request,
+): Promise<MeResponseData> {
+  const res = await client.get<ApiResponse<MeResponseData>>('/api/v2/auth/me')
+  return res.data.data
+}
+
+export async function apiMenus(
+  client: AxiosInstance = request,
+): Promise<MenuNode[]> {
+  const res = await client.get<ApiResponse<{ menus: MenuNode[] }>>(
+    '/api/v2/auth/menus',
+  )
+  return res.data.data.menus
+}

--- a/admin/src/stores/auth.ts
+++ b/admin/src/stores/auth.ts
@@ -1,0 +1,149 @@
+// Pinia auth store: holds the access/refresh tokens + current UserInfo.
+//
+// State is hydrated from localStorage on store creation so a page reload
+// keeps the user signed in until the refresh token expires (the axios
+// interceptor in api/request.ts will fetch a new access token on first
+// 401). Mutations always sync to localStorage via tokenStorage() (the
+// same source the axios interceptor reads from), so the persisted view
+// and the in-memory view stay in lockstep.
+
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+import type { AxiosInstance } from 'axios'
+import {
+  apiLogin,
+  apiLogout,
+  apiMe,
+  type MeResponseData,
+  type UserInfo,
+} from '../api/auth'
+import { tokenStorage } from '../api/tokenStorage'
+
+const USER_KEY = 'admin.user'
+
+function safeLocalStorage(): Storage | null {
+  return typeof localStorage === 'undefined' ? null : localStorage
+}
+
+function loadPersistedUser(): UserInfo | null {
+  const ls = safeLocalStorage()
+  if (!ls) return null
+  const raw = ls.getItem(USER_KEY)
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw)
+    if (
+      parsed &&
+      typeof parsed.id === 'number' &&
+      typeof parsed.username === 'string'
+    ) {
+      return parsed as UserInfo
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+function persistUser(u: UserInfo): void {
+  const ls = safeLocalStorage()
+  if (!ls) return
+  ls.setItem(USER_KEY, JSON.stringify(u))
+}
+
+function clearPersistedUser(): void {
+  const ls = safeLocalStorage()
+  if (!ls) return
+  ls.removeItem(USER_KEY)
+}
+
+// MeResponseData has richer role shape than UserInfo; flatten back into the
+// UserInfo shape that login returns, so consumers see one type.
+function meToUserInfo(me: MeResponseData): UserInfo {
+  return {
+    id: me.id,
+    username: me.username,
+    email: me.email,
+    displayName: me.displayName,
+    avatarUrl: me.avatarUrl,
+    isSuperAdmin: me.isSuperAdmin,
+    roles: me.roles.map((r) => r.code),
+  }
+}
+
+export const useAuthStore = defineStore('auth', () => {
+  const store = tokenStorage()
+
+  const accessToken = ref<string | null>(store.getAccess())
+  const refreshToken = ref<string | null>(store.getRefresh())
+  const user = ref<UserInfo | null>(loadPersistedUser())
+
+  const isAuthenticated = computed(
+    () => !!accessToken.value && !!user.value,
+  )
+
+  function setSession(access: string, refresh: string, u: UserInfo): void {
+    accessToken.value = access
+    refreshToken.value = refresh
+    user.value = u
+    store.setBoth(access, refresh)
+    persistUser(u)
+  }
+
+  function reset(): void {
+    accessToken.value = null
+    refreshToken.value = null
+    user.value = null
+    store.clear()
+    clearPersistedUser()
+  }
+
+  async function login(
+    email: string,
+    password: string,
+    client?: AxiosInstance,
+  ): Promise<UserInfo> {
+    const data = await apiLogin(email, password, client)
+    setSession(data.accessToken, data.refreshToken, data.user)
+    return data.user
+  }
+
+  async function logout(client?: AxiosInstance): Promise<void> {
+    try {
+      await apiLogout(client)
+    } catch {
+      // server-side logout is best-effort (stateless JWT — there's nothing
+      // for the server to invalidate). Always clear local state.
+    }
+    reset()
+  }
+
+  async function fetchMe(client?: AxiosInstance): Promise<UserInfo> {
+    const data = await apiMe(client)
+    const u = meToUserInfo(data)
+    user.value = u
+    persistUser(u)
+    return u
+  }
+
+  // Re-read access token from the storage layer. Useful after the axios
+  // interceptor performs a silent refresh: localStorage is already updated,
+  // but the reactive ref needs a manual nudge.
+  function syncFromStorage(): void {
+    accessToken.value = store.getAccess()
+    refreshToken.value = store.getRefresh()
+  }
+
+  return {
+    accessToken,
+    refreshToken,
+    user,
+    isAuthenticated,
+    login,
+    logout,
+    fetchMe,
+    reset,
+    setSession,
+    syncFromStorage,
+  }
+})


### PR DESCRIPTION
## Summary

Adds the Pinia `auth` store that owns `accessToken / refreshToken / user`, plus the typed API wrappers it calls. State persists to `localStorage` so reloads keep the user signed in.

Closes #22

## Files

| File | What |
|------|------|
| [admin/src/api/auth.ts](admin/src/api/auth.ts) | `apiLogin / apiLogout / apiMe / apiMenus` typed against the v2 admin endpoints. Each accepts an optional `AxiosInstance` so the verifier can pass a mock-bound client |
| [admin/src/stores/auth.ts](admin/src/stores/auth.ts) | `useAuthStore` with reactive refs + `isAuthenticated` computed + `login / logout / fetchMe / reset / setSession / syncFromStorage` actions |
| [admin/scripts/check-auth-store.ts](admin/scripts/check-auth-store.ts) | 47 assertions across 8 scenarios |

## Behavior

- **Hydrate on construction** — refs initialize from `tokenStorage()` (the singleton shared with `api/request.ts`) and `localStorage.admin.user`. Page reload brings the session back without a network round-trip.
- **Mutations write back to localStorage** — `login`, `setSession`, `fetchMe` persist; `logout` and `reset` clear. Same `admin.access_token / admin.refresh_token` keys the axios interceptor already reads, so the two layers stay in lockstep.
- **`logout()` is best-effort** — JWT is stateless, so a 5xx from `/api/v2/auth/logout` still clears local state. The client always wins.
- **`syncFromStorage()`** — a future hook for the axios interceptor's silent refresh: localStorage already has the new access token, this just nudges the reactive ref.
- **`fetchMe()` flattens role objects** — `/me` returns `roles: [{ id, code, name }]`; the store normalizes to `roles: string[]` so the same `UserInfo` shape from `/login` survives.

## Verification

```
$ cd admin && npx tsx scripts/check-auth-store.ts
[OK]  L1-L11 login persists everything (accessToken/refreshToken/user in store + localStorage)
[OK]  R1-R5  reload (fresh pinia, untouched localStorage) rehydrates state
[OK]  M1-M6  fetchMe overwrites user with /me data, persists, role codes flattened
[OK]  O1-O8  logout clears state + localStorage, server hit once
[OK]  F1-F4  logout still clears local state when server returns 500
[OK]  X1-X4  reset() clears without server call
[OK]  S0-S1  syncFromStorage picks up out-of-band token rotation
[OK]  A1-A4  bad creds throw, prior state preserved
PASS: auth store behavior verified.
```

`npm run build` still passes — 4136 modules, ~824ms.

## Verifier setup notes

- Polyfills `globalThis.localStorage` with an in-process `MemoryStorage` (real `localStorage` is browser-only)
- Uses `setActivePinia(createPinia())` so `useAuthStore()` runs without a Vue app
- Mocks `/api/v2/auth/login | /logout | /me` with a real `node:http` server; uses `createRequest({ baseURL })` with a `createMemoryTokenStore()` so each scenario gets isolated axios state
- Each scenario calls `freshAppState()` (new pinia + new localStorage) except R, which deliberately preserves localStorage to exercise the reload path

🤖 Generated with [Claude Code](https://claude.com/claude-code)