### PR TITLE
feat(T1.20): admin login page (/login)

### DIFF
--- a/admin/scripts/check-login-page.ts
+++ b/admin/scripts/check-login-page.ts
@@ -1,0 +1,379 @@
+// Verifies the behavior of admin/src/views/login/loginLogic.ts and the
+// auth store integration that views/login/index.vue relies on:
+//
+// extractErrorMessage:
+// - prefers AxiosError-shaped err.response.data.message
+// - falls back to "邮箱或密码错误" for 401 with no server message
+// - falls back to "网络异常" when err.response is undefined (axios network)
+// - falls back to err.message when present and not network-shaped
+// - returns generic "登录失败" for unknown shapes / null / undefined
+//
+// resolveRedirect:
+// - returns query.redirect when it is a relative path starting with '/'
+// - rejects "//host/path" (protocol-relative open redirect)
+// - rejects absolute URLs like "http://evil.com"
+// - defaults to "/dashboard" for missing / non-string redirect
+//
+// End-to-end (auth store + http mock):
+// - successful login: authStore.login(email, pw) resolves, fills the
+//   store, and tokens / user are set as the .vue would observe
+// - failed login (401): authStore.login throws an AxiosError that
+//   extractErrorMessage decodes back to the server's "Invalid email
+//   or password" string — exactly what the .vue surfaces in NAlert
+// - network failure (server stopped): authStore.login throws and
+//   extractErrorMessage returns the network fallback
+//
+// Usage (from admin/):
+//   npx tsx scripts/check-login-page.ts
+
+import http from 'node:http'
+
+class MemoryStorage {
+  private data = new Map<string, string>()
+  get length(): number {
+    return this.data.size
+  }
+  key(i: number): string | null {
+    return Array.from(this.data.keys())[i] ?? null
+  }
+  getItem(k: string): string | null {
+    return this.data.get(k) ?? null
+  }
+  setItem(k: string, v: string): void {
+    this.data.set(k, String(v))
+  }
+  removeItem(k: string): void {
+    this.data.delete(k)
+  }
+  clear(): void {
+    this.data.clear()
+  }
+}
+
+;(globalThis as unknown as { localStorage: MemoryStorage }).localStorage =
+  new MemoryStorage()
+
+const { createPinia, setActivePinia } = await import('pinia')
+const { createRequest } = await import('../src/api/request')
+const { createMemoryTokenStore } = await import('../src/api/tokenStorage')
+const { useAuthStore } = await import('../src/stores/auth')
+const { extractErrorMessage, resolveRedirect } = await import(
+  '../src/views/login/loginLogic'
+)
+
+const PORT = 33427
+const BASE = `http://localhost:${PORT}`
+
+interface MockState {
+  loginShouldFail: boolean
+  loginHits: number
+}
+
+function newMockState(): MockState {
+  return { loginShouldFail: false, loginHits: 0 }
+}
+
+let mock: MockState = newMockState()
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    let body = ''
+    req.on('data', (c) => {
+      body += c
+    })
+    req.on('end', () => resolve(body))
+  })
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = req.url || ''
+  res.setHeader('Content-Type', 'application/json')
+
+  if (url === '/api/v2/auth/login' && req.method === 'POST') {
+    mock.loginHits++
+    const body = await readBody(req)
+    if (mock.loginShouldFail) {
+      res.statusCode = 401
+      res.end(
+        JSON.stringify({ code: 401, message: 'Invalid email or password' }),
+      )
+      return
+    }
+    const parsed = JSON.parse(body) as { email?: string }
+    res.statusCode = 200
+    res.end(
+      JSON.stringify({
+        code: 200,
+        message: 'success',
+        data: {
+          accessToken: 'tok-A',
+          refreshToken: 'tok-R',
+          user: {
+            id: 7,
+            username: 'admin',
+            email: parsed.email ?? 'admin@example.com',
+            displayName: 'Admin',
+            avatarUrl: null,
+            isSuperAdmin: true,
+            roles: ['super_admin'],
+          },
+        },
+      }),
+    )
+    return
+  }
+
+  res.statusCode = 404
+  res.end(JSON.stringify({ code: 404, message: 'not found' }))
+})
+
+let pass = true
+function check(label: string, ok: boolean, detail?: string) {
+  const tag = ok ? 'OK  ' : 'FAIL'
+  console.log(`[${tag}] ${label}${detail ? '  -- ' + detail : ''}`)
+  if (!ok) pass = false
+}
+
+function freshAppState() {
+  setActivePinia(createPinia())
+  ;(globalThis as unknown as { localStorage: MemoryStorage }).localStorage =
+    new MemoryStorage()
+}
+
+function makeClient() {
+  return createRequest({
+    baseURL: BASE,
+    tokenStore: createMemoryTokenStore(),
+    onUnauthorized: () => {},
+  })
+}
+
+function runExtractErrorMessageCases() {
+  // E1: server-supplied message wins
+  check(
+    'E1: AxiosError with response.data.message → that string',
+    extractErrorMessage({
+      response: { status: 401, data: { message: 'Invalid email or password' } },
+      message: 'Request failed with status code 401',
+    }) === 'Invalid email or password',
+  )
+  // E2: 401 with no server message → friendly Chinese fallback
+  check(
+    'E2: 401 with no data.message → "邮箱或密码错误"',
+    extractErrorMessage({
+      response: { status: 401, data: null },
+      message: 'Request failed with status code 401',
+    }) === '邮箱或密码错误',
+  )
+  // E3: 500 with server message → that message
+  check(
+    'E3: 500 with server message → that message',
+    extractErrorMessage({
+      response: { status: 500, data: { message: 'database is on fire' } },
+    }) === 'database is on fire',
+  )
+  // E4: AxiosError with no response (network failure) → network fallback
+  check(
+    'E4: no response (network) → "网络异常,请稍后重试"',
+    extractErrorMessage({
+      message: 'Network Error',
+      // response is undefined
+    }) === '网络异常,请稍后重试',
+  )
+  // E5: plain Error with response present but missing data
+  check(
+    'E5: response exists, no data, status 500 → falls through to message',
+    extractErrorMessage({
+      response: { status: 500, data: null },
+      message: 'Boom',
+    }) === 'Boom',
+  )
+  // E6: undefined / null
+  check(
+    'E6: null → "登录失败,请重试"',
+    extractErrorMessage(null) === '登录失败,请重试',
+  )
+  check(
+    'E7: undefined → "登录失败,请重试"',
+    extractErrorMessage(undefined) === '登录失败,请重试',
+  )
+  // E8: Whitespace-only data.message must NOT win — fall through
+  check(
+    'E8: data.message="   " → does not win, falls through to status',
+    extractErrorMessage({
+      response: { status: 401, data: { message: '   ' } },
+    }) === '邮箱或密码错误',
+  )
+  // E9: data.message is non-string → ignored, falls through
+  check(
+    'E9: data.message is number 42 → ignored, falls through',
+    extractErrorMessage({
+      response: { status: 500, data: { message: 42 } },
+      message: 'fallback msg',
+    }) === 'fallback msg',
+  )
+}
+
+function runResolveRedirectCases() {
+  // R1: relative redirect honored
+  check(
+    'R1: query.redirect="/posts" → "/posts"',
+    resolveRedirect({ redirect: '/posts' }) === '/posts',
+  )
+  // R2: nested path
+  check(
+    'R2: query.redirect="/admin/users/42" → "/admin/users/42"',
+    resolveRedirect({ redirect: '/admin/users/42' }) === '/admin/users/42',
+  )
+  // R3: missing redirect → /dashboard
+  check(
+    'R3: empty query → "/dashboard"',
+    resolveRedirect({}) === '/dashboard',
+  )
+  // R4: protocol-relative open redirect rejected
+  check(
+    'R4: query.redirect="//evil.com/x" → "/dashboard" (rejected)',
+    resolveRedirect({ redirect: '//evil.com/x' }) === '/dashboard',
+  )
+  // R5: absolute URL rejected
+  check(
+    'R5: query.redirect="http://evil.com" → "/dashboard" (rejected)',
+    resolveRedirect({ redirect: 'http://evil.com' }) === '/dashboard',
+  )
+  // R6: non-string redirect (array — typical when ?redirect=a&redirect=b)
+  check(
+    'R6: query.redirect=["/a","/b"] → "/dashboard" (non-string ignored)',
+    resolveRedirect({ redirect: ['/a', '/b'] }) === '/dashboard',
+  )
+  // R7: empty string redirect
+  check(
+    'R7: query.redirect="" → "/dashboard" (empty rejected)',
+    resolveRedirect({ redirect: '' }) === '/dashboard',
+  )
+  // R8: path that does not start with /
+  check(
+    'R8: query.redirect="dashboard" → "/dashboard" (no leading slash rejected)',
+    resolveRedirect({ redirect: 'dashboard' }) === '/dashboard',
+  )
+}
+
+async function run() {
+  // === Phase 1: pure helpers (no server needed) ===
+  runExtractErrorMessageCases()
+  runResolveRedirectCases()
+
+  await new Promise<void>((resolve) => server.listen(PORT, resolve))
+
+  try {
+    // === S: end-to-end happy path ===
+    {
+      mock = newMockState()
+      freshAppState()
+      const auth = useAuthStore()
+      const client = makeClient()
+      let redirected: string | null = null
+      // Simulate what views/login/index.vue does in handleSubmit:
+      try {
+        await auth.login('admin@example.com', 'pw1234', client)
+        redirected = resolveRedirect({})
+      } catch (err) {
+        check(
+          'S0: happy path should not throw',
+          false,
+          extractErrorMessage(err),
+        )
+      }
+      check('S1: login hit server once', mock.loginHits === 1)
+      check('S2: store has tokens', auth.accessToken === 'tok-A')
+      check('S3: store has user', auth.user?.id === 7)
+      check('S4: isAuthenticated true', auth.isAuthenticated === true)
+      check(
+        'S5: would redirect to /dashboard (no query param)',
+        redirected === '/dashboard',
+      )
+    }
+
+    // === H: end-to-end happy path with redirect query ===
+    {
+      mock = newMockState()
+      freshAppState()
+      const auth = useAuthStore()
+      const client = makeClient()
+      await auth.login('admin@example.com', 'pw1234', client)
+      const target = resolveRedirect({ redirect: '/posts' })
+      check('H1: redirect query honored', target === '/posts')
+    }
+
+    // === F: end-to-end failure path — bad creds ===
+    {
+      mock = newMockState()
+      mock.loginShouldFail = true
+      freshAppState()
+      const auth = useAuthStore()
+      const client = makeClient()
+      let caught: unknown = null
+      try {
+        await auth.login('admin@example.com', 'wrong', client)
+      } catch (err) {
+        caught = err
+      }
+      check('F1: bad creds threw', caught !== null)
+      const msg = extractErrorMessage(caught)
+      // Server returned data.message="Invalid email or password" — that is
+      // what extractErrorMessage prefers, and what NAlert would display.
+      check(
+        'F2: extracted message matches server text',
+        msg === 'Invalid email or password',
+        `got: ${msg}`,
+      )
+      check('F3: store NOT authenticated', auth.isAuthenticated === false)
+      check('F4: store has no tokens', auth.accessToken === null)
+    }
+
+    // === N: network failure path — server stopped ===
+    {
+      mock = newMockState()
+      freshAppState()
+      const auth = useAuthStore()
+      const client = makeClient()
+      // Stop the server temporarily to force a network error.
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      )
+      let caught: unknown = null
+      try {
+        await auth.login('admin@example.com', 'pw1234', client)
+      } catch (err) {
+        caught = err
+      }
+      check('N1: network error threw', caught !== null)
+      const msg = extractErrorMessage(caught)
+      check(
+        'N2: network fallback message',
+        msg === '网络异常,请稍后重试' || msg === 'Network Error',
+        `got: ${msg}`,
+      )
+      check('N3: store NOT authenticated', auth.isAuthenticated === false)
+    }
+  } finally {
+    // server may already be closed by the network-failure scenario.
+    try {
+      server.close()
+    } catch {
+      // already closed
+    }
+  }
+
+  console.log('')
+  console.log(
+    pass
+      ? 'PASS: login page logic verified.'
+      : 'FAIL: see [FAIL] entries above.',
+  )
+  process.exit(pass ? 0 : 1)
+}
+
+run().catch((err) => {
+  console.error('UNEXPECTED ERROR:', err)
+  process.exit(1)
+})

--- a/admin/src/router/index.ts
+++ b/admin/src/router/index.ts
@@ -13,6 +13,12 @@ const router = createRouter({
       name: 'about',
       component: () => import('../views/About.vue'),
     },
+    {
+      path: '/login',
+      name: 'login',
+      component: () => import('../views/login/index.vue'),
+      meta: { public: true },
+    },
   ],
 })
 

--- a/admin/src/views/login/index.vue
+++ b/admin/src/views/login/index.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+// Admin login page. Shape: NCard wrapping NForm with email + password +
+// submit. On success, redirects to ?redirect or /dashboard via
+// router.replace (so the login page doesn't sit in history). On failure,
+// displays the server's message inline via NAlert; the form fields stay
+// filled so the user can correct just the password.
+
+import { reactive, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  NAlert,
+  NButton,
+  NCard,
+  NForm,
+  NFormItem,
+  NInput,
+  type FormInst,
+  type FormRules,
+} from 'naive-ui'
+import { useAuthStore } from '../../stores/auth'
+import { extractErrorMessage, resolveRedirect } from './loginLogic'
+
+const router = useRouter()
+const route = useRoute()
+const authStore = useAuthStore()
+
+const formRef = ref<FormInst | null>(null)
+const loading = ref(false)
+const errorMessage = ref('')
+
+const form = reactive({
+  email: '',
+  password: '',
+})
+
+const rules: FormRules = {
+  email: [
+    { required: true, message: '请输入邮箱', trigger: ['blur', 'input'] },
+    { type: 'email', message: '请输入合法的邮箱地址', trigger: ['blur'] },
+  ],
+  password: [
+    { required: true, message: '请输入密码', trigger: ['blur', 'input'] },
+    { min: 6, message: '密码至少 6 位', trigger: ['blur'] },
+  ],
+}
+
+async function handleSubmit(): Promise<void> {
+  if (loading.value) return
+  errorMessage.value = ''
+  if (!formRef.value) return
+  try {
+    await formRef.value.validate()
+  } catch {
+    return
+  }
+  loading.value = true
+  try {
+    await authStore.login(form.email.trim(), form.password)
+    const target = resolveRedirect(route.query)
+    await router.replace(target)
+  } catch (err) {
+    errorMessage.value = extractErrorMessage(err)
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="login-page">
+    <NCard class="login-card" title="管理后台登录" :bordered="true">
+      <NAlert
+        v-if="errorMessage"
+        type="error"
+        :show-icon="false"
+        class="login-alert"
+      >
+        {{ errorMessage }}
+      </NAlert>
+      <NForm
+        ref="formRef"
+        :model="form"
+        :rules="rules"
+        label-placement="top"
+        :show-require-mark="false"
+        @keyup.enter="handleSubmit"
+      >
+        <NFormItem label="邮箱" path="email">
+          <NInput
+            v-model:value="form.email"
+            placeholder="admin@example.com"
+            :disabled="loading"
+            autocomplete="username"
+          />
+        </NFormItem>
+        <NFormItem label="密码" path="password">
+          <NInput
+            v-model:value="form.password"
+            type="password"
+            show-password-on="click"
+            placeholder="请输入密码"
+            :disabled="loading"
+            autocomplete="current-password"
+          />
+        </NFormItem>
+        <NButton
+          type="primary"
+          block
+          :loading="loading"
+          :disabled="loading"
+          @click="handleSubmit"
+        >
+          登录
+        </NButton>
+      </NForm>
+    </NCard>
+  </div>
+</template>
+
+<style scoped>
+.login-page {
+  min-height: 100svh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 420px;
+}
+
+.login-alert {
+  margin-bottom: 16px;
+}
+</style>

--- a/admin/src/views/login/loginLogic.ts
+++ b/admin/src/views/login/loginLogic.ts
@@ -1,0 +1,59 @@
+// Pure helpers for views/login/index.vue. Kept separate so the SFC stays
+// small and the decision logic is unit-testable without a DOM.
+//
+// extractErrorMessage(err): turn whatever was thrown by authStore.login()
+//   into a human-readable string. Priority:
+//     1. AxiosError-shaped: err.response.data.message (server's own copy)
+//     2. AxiosError-shaped, 401 with no message: '邮箱或密码错误'
+//     3. AxiosError-shaped, network failure / no response: '网络异常,请稍后重试'
+//     4. Error.message
+//     5. Fallback: '登录失败,请重试'
+//
+// resolveRedirect(query): pick the post-login destination. Trusts an
+// in-app redirect param (anything starting with '/') and ignores absolute
+// URLs to avoid open-redirect to attacker-controlled hosts. Defaults to
+// '/dashboard' (T1.23 will register that route).
+
+import type { LocationQuery } from 'vue-router'
+
+interface AxiosLikeError {
+  response?: {
+    status?: number
+    data?: { message?: unknown } | null
+  }
+  message?: string
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null
+}
+
+export function extractErrorMessage(err: unknown): string {
+  if (isObject(err)) {
+    const e = err as AxiosLikeError
+    const data = e.response?.data
+    if (isObject(data) && typeof data.message === 'string' && data.message.trim()) {
+      return data.message
+    }
+    if (e.response?.status === 401) {
+      return '邮箱或密码错误'
+    }
+    if (e.response === undefined && typeof e.message === 'string' && e.message) {
+      // No response object at all = network/timeout (axios sets err.message
+      // but err.response is undefined).
+      return '网络异常,请稍后重试'
+    }
+    if (typeof e.message === 'string' && e.message.trim()) {
+      return e.message
+    }
+  }
+  return '登录失败,请重试'
+}
+
+export function resolveRedirect(query: LocationQuery | Record<string, unknown>): string {
+  const raw = (query as Record<string, unknown>).redirect
+  if (typeof raw === 'string' && raw.startsWith('/') && !raw.startsWith('//')) {
+    return raw
+  }
+  return '/dashboard'
+}


### PR DESCRIPTION
## Summary
- New `/login` route rendering `views/login/index.vue` — Naive UI card with email + password form, inline error alert, loading spinner on the submit button. Enter key submits; double-click is a no-op while a request is in flight.
- On success, `router.replace(resolveRedirect(route.query))` — defaults to `/dashboard`, honors `?redirect=/some/path` only when it's a same-origin relative path (rejects `//host/...` and `http(s)://...` to prevent open-redirect).
- On failure, surfaces the server's `data.message` via `NAlert` and leaves the form populated. 401 with no body falls back to `邮箱或密码错误`; total network failure falls back to `网络异常,请稍后重试`.
- Helpers (`extractErrorMessage`, `resolveRedirect`) extracted to `views/login/loginLogic.ts` so they're unit-testable without DOM.
- `meta.public = true` on the route is a hint for T1.21's route guard.

## Verification
- `npx tsx admin/scripts/check-login-page.ts` — 30 assertions:
  - `extractErrorMessage` × 9: server message wins, 401 friendly fallback, 500 server message, network fallback, null/undefined, whitespace-only & non-string ignored.
  - `resolveRedirect` × 8: relative paths honored, `//host` + `http://` + non-string + empty + no-leading-slash all rejected.
  - End-to-end × 13 against http mock: happy path fills store and resolves redirect; 401 path extracts server text, leaves store unauthenticated; network failure (server stopped mid-test) returns network fallback message.
- `npm run build` (vue-tsc + vite): clean. New chunk `login-*.js` (~131 KB / 43 KB gzip) lazy-loaded on `/login`.
- T1.17 / T1.18 / T1.19 verifiers re-run green.

## Test plan
- [x] `npx tsx scripts/check-login-page.ts` → PASS (30/30)
- [x] `npm run build` → 0 type errors, dist built, login chunk emitted
- [x] T1.17 `check-axios-request.ts` still PASS
- [x] T1.18 `check-auth-store.ts` still PASS
- [x] T1.19 `check-permission-store.ts` still PASS

## Out of scope (deferred)
- Route guard for protected routes — T1.21
- `/dashboard` route target — T1.23
- AdminLayout shell — T1.22

Closes #24