### PR TITLE
feat(T1.24): add v-permission directive and verifier

### DIFF
--- a/admin/scripts/check-v-permission.ts
+++ b/admin/scripts/check-v-permission.ts
@@ -1,0 +1,155 @@
+// Verifies v-permission directive behavior.
+//
+// Checks:
+// - Single permission string: element removed when denied, kept when granted.
+// - Array of permissions (OR logic): kept if ANY granted, removed if all denied.
+// - Dynamic update: restore element when permission changes from denied to granted.
+// - super_admin bypass: element always kept.
+//
+// Usage (from admin/):
+//   npx tsx scripts/check-v-permission.ts
+
+class MemoryStorage {
+  private data = new Map<string, string>()
+  get length(): number { return this.data.size }
+  key(i: number): string | null {
+    return Array.from(this.data.keys())[i] ?? null
+  }
+  getItem(k: string): string | null {
+    return this.data.get(k) ?? null
+  }
+  setItem(k: string, v: string): void {
+    this.data.set(k, String(v))
+  }
+  removeItem(k: string): void {
+    this.data.delete(k)
+  }
+  clear(): void {
+    this.data.clear()
+  }
+}
+
+;(globalThis as unknown as { localStorage: MemoryStorage }).localStorage =
+  new MemoryStorage()
+
+import { createPinia, setActivePinia } from 'pinia'
+
+setActivePinia(createPinia())
+
+// Pre-seed the permission store before the directive lazily creates it.
+const { usePermissionStore } = await import('../src/stores/permission')
+const perm = usePermissionStore()
+perm.permissionCodes = new Set(['post:list', 'post:create'])
+
+const { vPermission } = await import('../src/directives/permission')
+
+// Minimal DOM mock sufficient for the directive's operations.
+class MockParent {
+  children: MockEl[] = []
+  insertBefore(el: MockEl, next: MockEl | null): void {
+    const idx = next ? this.children.indexOf(next) : this.children.length
+    this.children.splice(idx, 0, el)
+    el.parentNode = this
+  }
+}
+
+class MockEl {
+  parentNode: MockParent | null = null
+  nextSibling: MockEl | null = null
+  remove(): void {
+    if (this.parentNode) {
+      const idx = this.parentNode.children.indexOf(this)
+      if (idx >= 0) this.parentNode.children.splice(idx, 1)
+      this.parentNode = null
+    }
+  }
+}
+
+function makeEl(): MockEl {
+  const parent = new MockParent()
+  const el = new MockEl()
+  el.parentNode = parent
+  parent.children.push(el)
+  return el
+}
+
+let pass = true
+function check(label: string, ok: boolean, detail?: string) {
+  const tag = ok ? 'OK  ' : 'FAIL'
+  console.log(`[${tag}] ${label}${detail ? '  -- ' + detail : ''}`)
+  if (!ok) pass = false
+}
+
+// === Single string value ===
+{
+  const el = makeEl()
+  vPermission.mounted(el as unknown as HTMLElement, { value: 'post:list' } as any)
+  check('S1: granted single → kept in DOM', el.parentNode !== null)
+}
+
+{
+  const el = makeEl()
+  vPermission.mounted(el as unknown as HTMLElement, { value: 'user:delete' } as any)
+  check('S2: denied single → removed from DOM', el.parentNode === null)
+}
+
+// === Array value (OR) ===
+{
+  const el = makeEl()
+  vPermission.mounted(el as unknown as HTMLElement, { value: ['user:delete', 'post:create'] } as any)
+  check('A1: array with one granted → kept', el.parentNode !== null)
+}
+
+{
+  const el = makeEl()
+  vPermission.mounted(el as unknown as HTMLElement, { value: ['user:delete', 'role:admin'] } as any)
+  check('A2: array with none granted → removed', el.parentNode === null)
+}
+
+// === Dynamic update ===
+{
+  const el = makeEl()
+  vPermission.mounted(el as unknown as HTMLElement, { value: 'user:delete' } as any)
+  check('U1: initially removed', el.parentNode === null)
+
+  vPermission.updated(el as unknown as HTMLElement, { value: 'post:list' } as any)
+  check('U2: updated to granted → restored', el.parentNode !== null)
+}
+
+{
+  const el = makeEl()
+  vPermission.mounted(el as unknown as HTMLElement, { value: 'post:list' } as any)
+  check('U3: initially kept', el.parentNode !== null)
+
+  vPermission.updated(el as unknown as HTMLElement, { value: 'user:delete' } as any)
+  check('U4: updated to denied → removed', el.parentNode === null)
+}
+
+// === super_admin bypass ===
+{
+  const { useAuthStore } = await import('../src/stores/auth')
+  const auth = useAuthStore()
+  auth.setSession('tok', 'ref', {
+    id: 1,
+    username: 'sa',
+    email: 'sa@x.com',
+    displayName: null,
+    avatarUrl: null,
+    isSuperAdmin: true,
+    roles: ['super_admin'],
+  })
+
+  const el = makeEl()
+  vPermission.mounted(el as unknown as HTMLElement, { value: 'anything:wild' } as any)
+  check('SA1: super_admin → kept regardless', el.parentNode !== null)
+
+  auth.reset()
+}
+
+console.log('')
+console.log(
+  pass
+    ? 'PASS: v-permission directive verified.'
+    : 'FAIL: see [FAIL] entries above.',
+)
+process.exit(pass ? 0 : 1)

--- a/admin/src/directives/permission.ts
+++ b/admin/src/directives/permission.ts
@@ -1,0 +1,48 @@
+import type { DirectiveBinding } from 'vue'
+import { usePermissionStore } from '../stores/permission'
+
+type PermissionValue = string | string[]
+
+const removedNodes = new WeakMap<
+  Element,
+  { parent: ParentNode; next: Node | null }
+>()
+
+function hasPermission(value: PermissionValue): boolean {
+  const perm = usePermissionStore()
+  if (Array.isArray(value)) {
+    return value.some((code) => perm.hasPermission(code))
+  }
+  return perm.hasPermission(value)
+}
+
+function remove(el: HTMLElement): void {
+  if (!el.parentNode) return
+  removedNodes.set(el, { parent: el.parentNode, next: el.nextSibling })
+  el.remove()
+}
+
+function restore(el: HTMLElement): void {
+  const info = removedNodes.get(el)
+  if (!info) return
+  info.parent.insertBefore(el, info.next)
+  removedNodes.delete(el)
+}
+
+export const vPermission = {
+  mounted(el: HTMLElement, binding: DirectiveBinding<PermissionValue>) {
+    if (!hasPermission(binding.value)) {
+      remove(el)
+    }
+  },
+  updated(el: HTMLElement, binding: DirectiveBinding<PermissionValue>) {
+    const hasPerm = hasPermission(binding.value)
+    const isRemoved = removedNodes.has(el)
+
+    if (hasPerm && isRemoved) {
+      restore(el)
+    } else if (!hasPerm && !isRemoved) {
+      remove(el)
+    }
+  },
+}

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -3,8 +3,10 @@ import { createPinia } from 'pinia'
 import './style.css'
 import App from './App.vue'
 import router from './router'
+import { vPermission } from './directives/permission'
 
 const app = createApp(App)
 app.use(createPinia())
 app.use(router)
+app.directive('permission', vPermission)
 app.mount('#app')


### PR DESCRIPTION
## Summary
- v-permission directive: controls element visibility based on permission codes.
- Supports single string `v-permission="'post:list'"` or array `v-permission="['post:list', 'post:create']"` (OR logic).
- Removes element from DOM when denied; restores on dynamic updates.
- super_admin bypass supported via permission store.
- 9-assertion verifier + npm run build clean.

Closes #28