### PR TITLE
feat(T1.26): update docs for Phase 1 completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+## Phase 1 — 基础脚手架（2026-05-03）
+
+Phase 1 完成双端口后端骨架、JWT 认证体系、RBAC 种子、Vue 3 SPA 登录闭环。
+
+### 后端
+
+- **T1.1** 新建后端目录结构：`middleware/`、`apps/`、`modules/`、`jobs/`、`seeds/`。
+- **T1.2** 安装新依赖：`jsonwebtoken`、`bcryptjs`、`cors`、`joi`、`helmet`。
+- **T1.3** 数据库迁移：新增 10 张 v2 表 — `users`、`roles`、`permissions`、`role_permissions`、`user_roles`、`menus`、`audit_logs`、`front_users`、`page_views`、`sites`。
+- **T1.4** RBAC 种子：12 个权限、3 个角色、默认菜单树、超级管理员账号（从 `.env` 读取）。
+- **T1.5** 拆分 `apps/frontApp.js`，将原 880 行 monolith 迁入，保留全部现有路由和中间件。
+- **T1.6** 新建 `apps/adminApp.js`，挂载 `/api/v2` 前缀。
+- **T1.7** 改造 `index.js` 为双端口同进程启动（frontApp@8787 + adminApp@3000）。
+- **T1.8** 开发环境 CORS 中间件（5173 / 8787 → 3000）。
+- **T1.9** JWT 认证中间件 — accessToken 校验、挂载 `req.user`。
+- **T1.10** RBAC 中间件 — `requirePermission(code)`，超管直接放行。
+- **T1.11** `/api/v2/auth/login` — bcrypt 校验、签发 access + refresh token。
+- **T1.12** `/api/v2/auth/refresh` — refresh token 校验与续期。
+- **T1.13** `/api/v2/auth/logout`、`/api/v2/auth/me`、`/api/v2/auth/menus` — `/menus` 按用户角色返回过滤后的树。
+
+### 前端（admin/）
+
+- **T1.14** 初始化 Vue 3 + Vite + TypeScript 项目。
+- **T1.15** 配置 Naive UI、Tailwind CSS、Pinia、Vue Router。
+- **T1.16** Vite 代理配置 — `/api` 转发到 `localhost:3000`。
+- **T1.17** Axios 请求模块 — Bearer 注入、401 自动刷新、并发 dedup。
+- **T1.18** `stores/auth.ts` — token + 用户信息 + login/logout/fetchMe，localStorage 持久化。
+- **T1.19** `stores/permission.ts` — 菜单树 + 权限码集合，`hasPermission(code)` 含超管 bypass。
+- **T1.20** 登录页 — 表单 + 错误提取 + open-redirect 防护 + 网络异常兜底。
+- **T1.21** 路由守卫 — public 路由、未登录重定向、已登录访问 /login 跳 dashboard、bootstrap 去重、权限门控、失败清理。
+- **T1.22** `AdminLayout.vue` — 可折叠侧边栏（按权限渲染菜单）、顶栏（面包屑 + 用户下拉）、主区域 RouterView。
+- **T1.23** Dashboard 占位页 — 欢迎语 + 统计卡片占位。
+- **T1.24** `v-permission` 指令 — 支持单值和数组（OR 逻辑），无权限时 DOM 不生成。
+- **T1.25** Phase 1 集成验收脚本 — 端到端验证：登录 → bootstrap → dashboard → 权限校验 → 登出。
+
+### 文档
+
+- **T1.26** 更新 `CLAUDE.md`（双端口架构、目录结构、API 路由、前端模块）。
+- **T1.26** 新建 `README.md`（5 分钟快速开始 + 项目结构 + 常用命令）。
+- **T1.26** 新建 `CHANGELOG.md`（Phase 1 变更汇总）。
+
+---
+
+## 后续阶段（计划中）
+
+- **Phase 2** — RBAC + CMS 迁移（用户/角色/权限/菜单管理页，文章/标签/分类/友链 CRUD）
+- **Phase 3** — 数据分析（PV/UV 采集、Dashboard 图表）
+- **Phase 4** — 运维监控（审计日志、备份、系统状态看板）
+- **Phase 5** — 上线 + 旧 EJS 后台下线

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,77 +4,131 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-ifoxchen's personal blog (ifoxchen.com) — a full-stack blog with Express 5 + SQLite backend, static HTML frontend with vanilla JS, and a cyberpunk-themed multi-theme design system.
+ifoxchen's personal blog (ifoxchen.com) — a full-stack blog with a dual-port architecture:
+- **Front port (8787)**: Express 5 + SQLite legacy blog (static HTML frontend, EJS admin).
+- **Admin port (3000)**: Express 5 + JWT + RBAC v2 API, consumed by a Vue 3 SPA in `admin/`.
+
+Phase 1 (completed) established the dual-port foundation, JWT auth, RBAC seed, and the Vue 3 admin skeleton.
 
 ## Commands
 
-The **server directory** has its own `package.json` with the actual dependencies. The root `package.json` is used by Docker.
+### Server (from `server/` directory)
 
 ```bash
-# Local development (from server/ directory)
-cd server && npm install && npm run dev    # nodemon auto-reload
+cd server && npm install && npm run dev    # nodemon auto-reload, both ports
 cd server && npm start                     # production mode
-
-# Docker
-docker build -t blog-design .
-docker run -p 8787:8787 blog-design
-
-# Deploy to remote server (from project root)
-bash deploy.sh
-# Or use AGENTS.md for manual SCP + SSH deployment steps
 ```
 
-**No test suite or linter is configured.**
+### Admin SPA (from `admin/` directory)
+
+```bash
+cd admin && npm install && npm run dev     # Vite dev server on 5173
+cd admin && npm run build                  # vue-tsc + vite build → dist/
+```
+
+### Docker (from project root)
+
+```bash
+docker build -t blog-design .
+docker run -p 8787:8787 -p 3000:3000 blog-design
+```
+
+### Deploy
+
+```bash
+bash deploy.sh
+```
+
+**No test suite or linter is configured.** Verification is done via `npx tsx scripts/check-*.ts` scripts.
 
 ## Architecture
 
 ### Backend (`server/`)
 
-- **`server/src/index.js`** — Main entry point. All routes defined here (REST API + admin EJS pages). Single-file monolith.
-- **`server/src/db.js`** — SQLite setup via `better-sqlite3`. Schema migration (CREATE IF NOT EXISTS), seed data, tag/category CRUD helpers. DB file at `server/db/blog.sqlite`.
-- **`server/src/auth.js`** — Session-based admin auth. Supports plaintext password or bcrypt hash (`ADMIN_PASSWORD_HASH`). Uses constant-time comparison.
-- **`server/src/markdown.js`** — Markdown-to-HTML via `marked` + `sanitize-html` with conservative allowlist.
-- **`server/src/env.js`** — Custom `.env` loader (reads `server/.env`). Exports `required()` / `optional()`.
-- **`server/src/utils.js`** — `nowIso()`, `toInt()`, `normalizeSlug()` (via slugify), `splitTags()`.
-- **`server/views/`** — EJS templates: `login.ejs`, `posts.ejs` (list), `edit.ejs` (create/edit), `links.ejs`.
+**Dual-port entry**: `server/src/index.js` bootstraps two Express apps:
+- `frontApp` @ `PORT` (default 8787) — legacy blog + EJS admin.
+- `adminApp` @ `ADMIN_PORT` (default 3000) — v2 JWT/RBAC API.
 
-### Frontend (root level)
+**Key files**:
+- `server/src/apps/frontApp.js` — Lift-and-shift of the original 880-line monolith (public API + old admin EJS + old admin API).
+- `server/src/apps/adminApp.js` — v2 API mount point (`/api/v2`).
+- `server/src/db.js` — SQLite via `better-sqlite3`. Schema migration, seed data, CRUD helpers. DB at `server/db/blog.sqlite`.
+- `server/src/auth.js` — Session-based auth (legacy EJS admin). Constant-time comparison, bcrypt hash support.
+- `server/src/middleware/jwtAuth.js` — Access-token verification, mounts `req.user`.
+- `server/src/middleware/rbac.js` — `requirePermission(code)` factory. Super admin bypass.
+- `server/src/middleware/cors.js` — Dev-only CORS (5173 / 8787 → 3000).
+- `server/src/seeds/rbacSeed.js` — RBAC seed: 12 permissions, 3 roles, default menu tree, super admin.
+- `server/src/env.js` — `.env` loader. Exports `required()` / `optional()`.
+- `server/src/utils.js` — `nowIso()`, `toInt()`, `normalizeSlug()`, `splitTags()`.
 
-Static HTML pages served by Express from the project root:
-- `index.html` — Homepage with latest posts grid
-- `post.html` — Single article view (slug-based)
-- `archive.html` — Post archive with tag/category filtering and pagination
-- `links.html` — External navigation links
-- `about.html` — About page
-- `components.html` — Component index/design reference
+**Database Schema (SQLite)**:
+- Legacy: `posts`, `tags`, `post_tags`, `categories`, `post_categories`, `external_links`.
+- v2 RBAC: `users`, `roles`, `permissions`, `role_permissions`, `user_roles`, `menus`.
+- v2 audit/ops: `audit_logs`, `front_users`, `page_views`, `sites`.
 
-- **`js/blog.js`** — Page hydration: fetches from `/api/posts`, `/api/posts/:slug`, `/api/tags`, `/api/categories` and renders into the DOM. Handles index, archive, and post pages.
-- **`js/theme.js`** — Theme system: 11 themes (cyberpunk, aurora, synthwave, neon, matrix, nord, dracula, github, monokai, sunset, forest) + dark/light mode. Persisted in localStorage.
-- **`css/tokens.css`** — Design tokens (CSS custom properties): colors, typography, spacing. Theme variants defined here via `[data-theme="..."]` selectors.
-- **`css/base.css`** — Reset and base styles.
-- **`css/components.css`** — Component styles (cards, nav, footer, etc.).
+### Frontend — Legacy (root level)
+
+Static HTML served by `frontApp` from project root:
+- `index.html`, `post.html`, `archive.html`, `links.html`, `about.html`, `components.html`
+- `js/blog.js` — Page hydration (fetches `/api/posts`, `/api/posts/:slug`, `/api/tags`, `/api/categories`).
+- `js/theme.js` — 11 themes + dark/light mode.
+- `css/tokens.css`, `css/base.css`, `css/components.css` — Design system.
+
+### Frontend — Admin v2 (`admin/`)
+
+Vue 3.5 + Vite 8 + TypeScript + Naive UI + Pinia 3 + Vue Router 5.
+
+**Key files**:
+- `admin/src/main.ts` — App bootstrap, global `v-permission` directive.
+- `admin/src/router/index.ts` — Route definitions, `/dashboard` nested under `AdminLayout`.
+- `admin/src/router/guards.ts` — `beforeEach`/`afterEach`: public routes, auth redirect, bootstrap dedup (`/me` + `/menus` once), permission gate, failure handling.
+- `admin/src/stores/auth.ts` — Pinia store: tokens, user info, login/logout/fetchMe. Hydrated from localStorage.
+- `admin/src/stores/permission.ts` — Menu tree + permission code set. `hasPermission(code)` with super_admin bypass.
+- `admin/src/api/request.ts` — Axios instance with Bearer injection, 401 → refresh + retry, 401-refresh-fail → `onUnauthorized`.
+- `admin/src/api/auth.ts` — Typed wrappers: `apiLogin`, `apiLogout`, `apiMe`, `apiMenus`.
+- `admin/src/components/layout/AdminLayout.vue` — Collapsible sidebar (menu from store), top bar (logo, breadcrumb, user dropdown), main `<RouterView>`.
+- `admin/src/views/dashboard/index.vue` — Dashboard placeholder (welcome + stat cards).
+- `admin/src/views/login/index.vue` — Login form with `extractErrorMessage` + `resolveRedirect` helpers.
+- `admin/src/views/error/403.vue` — Forbidden page with `from` query display.
+- `admin/src/directives/permission.ts` — `v-permission="'post:list'"` or `v-permission="['post:list', 'post:create']"`. Removes DOM element when denied.
+
+**Verifier scripts** (run from `admin/`):
+- `scripts/check-auth-store.ts` — Login, hydration, logout, reset.
+- `scripts/check-axios-request.ts` — Token injection, 401 refresh, concurrent dedup.
+- `scripts/check-permission-store.ts` — loadMenus, loadPermissions, hasPermission, reset.
+- `scripts/check-login-page.ts` — extractErrorMessage, resolveRedirect, e2e login.
+- `scripts/check-route-guards.ts` — Public routes, auth redirect, bootstrap once, permission gate, failure.
+- `scripts/check-admin-layout.ts` — Menu helpers, router nesting.
+- `scripts/check-dashboard.ts` — Dashboard content + route wiring.
+- `scripts/check-v-permission.ts` — Directive single/array/OR, dynamic update, super_admin.
+- `scripts/check-integration.ts` — End-to-end: login → bootstrap → dashboard → logout.
 
 ### API Routes
 
-Public: `GET /api/posts`, `GET /api/posts/:slug`, `GET /api/tags`, `GET /api/categories`, `GET /api/links`, `GET /rss.xml`
+**Public (frontApp)**:
+- `GET /api/posts`, `GET /api/posts/:slug`, `GET /api/tags`, `GET /api/categories`, `GET /api/links`, `GET /rss.xml`
 
-Admin (session auth required): `/api/admin/posts` (CRUD), `/api/admin/posts/:id/publish|unpublish`, `/api/admin/links` (CRUD), `/api/admin/upload` (image), `/api/admin/export`, `/api/admin/import`
+**Legacy admin (frontApp, session auth)**:
+- `/api/admin/posts` (CRUD), `/api/admin/posts/:id/publish|unpublish`, `/api/admin/links`, `/api/admin/upload`, `/api/admin/export`, `/api/admin/import`
+- EJS pages: `/admin/login`, `/admin/posts`, `/admin/posts/new`, `/admin/posts/:id/edit`, `/admin/links`
 
-Admin pages (EJS): `/admin/login`, `/admin/posts`, `/admin/posts/new`, `/admin/posts/:id/edit`, `/admin/links`
+**v2 admin (adminApp, JWT auth)**:
+- `POST /api/v2/auth/login` — bcrypt, returns access + refresh tokens.
+- `POST /api/v2/auth/refresh` — refresh token → new access token.
+- `POST /api/v2/auth/logout` — best-effort server-side.
+- `GET /api/v2/auth/me` — user profile + permissions.
+- `GET /api/v2/auth/menus` — server-side filtered menu tree.
 
-### Database Schema (SQLite)
-
-Tables: `posts`, `tags`, `post_tags` (M2M), `categories`, `post_categories` (M2M), `external_links`. All timestamps as ISO strings.
-
-### Deployment
-
-Docker container on `192.168.3.100:8787`. Volumes persist `server/db/` (SQLite) and `server/public/uploads/` (images). SSH key at `C:/Users/陈科/.ssh/blog_deploy`. See `AGENTS.md` for detailed deployment steps.
+Standard response shape: `{ code, message, data }`.
 
 ## Key Conventions
 
 - Server uses CommonJS (`require`/`module.exports`), not ESM.
-- Two `package.json` files: root (Docker context) and `server/` (dev). Install deps in `server/`.
-- Admin auth is session-based (express-session), not JWT.
-- Markdown content stored raw in DB; `contentHtml` is lazily rendered (set to NULL on update, rendered on read).
-- Slugs are generated via `slugify` with `strict: true` (lowercase, alphanumeric + hyphens only).
+- Admin uses ESM + TypeScript (`import`/`export`).
+- Two `package.json` files: root (Docker) and `server/` (dev backend) and `admin/` (Vue SPA). Install deps in the respective directory.
+- Legacy admin auth is session-based (express-session); v2 admin auth is JWT (Bearer tokens).
+- JWT payload: `{ userId, username, roles, type: 'admin' }` (2h access) + `{ userId, type: 'refresh' }` (7d).
+- Super admin (`is_super_admin = 1` or `user.isSuperAdmin`) bypasses all RBAC checks.
+- Markdown content stored raw in DB; `contentHtml` lazily rendered on read.
+- Slugs via `slugify` with `strict: true`.
 - Environment variables loaded from `server/.env` (copy from `.env.example`).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,119 @@
+# ifoxchen.com Blog v2
+
+个人博客全栈项目 —— Express 5 + SQLite 后端，静态 HTML 前台，Vue 3 管理后台。
+
+## 快速开始（5 分钟）
+
+### 1. 克隆并安装依赖
+
+```bash
+git clone <your-repo-url> blog-design-v2.0
+cd blog-design-v2.0
+
+# 后端依赖
+cd server && npm install
+
+# 前端依赖（另一个终端）
+cd admin && npm install
+```
+
+### 2. 配置环境变量
+
+```bash
+cp server/.env.example server/.env
+# 编辑 server/.env，设置 ADMIN_EMAIL 和 ADMIN_PASSWORD（或 ADMIN_PASSWORD_HASH）
+```
+
+### 3. 启动服务
+
+**终端 A — 后端**（同时启动两个端口）：
+
+```bash
+cd server && npm run dev
+```
+
+日志输出示例：
+
+```
+Front : http://localhost:8787
+Legacy admin (EJS) : http://localhost:8787/admin/login
+Admin v2 API : http://localhost:3000/api/v2
+```
+
+**终端 B — 前端开发服务器**：
+
+```bash
+cd admin && npm run dev
+```
+
+打开 http://localhost:5173 进入 Vue 后台登录页。
+
+### 4. 首次登录
+
+使用 `.env` 中配置的 `ADMIN_EMAIL` / `ADMIN_PASSWORD` 登录。
+
+---
+
+## 项目结构
+
+```
+.
+├── server/                 # Express 5 后端
+│   ├── src/
+│   │   ├── apps/           # frontApp.js (8787) + adminApp.js (3000)
+│   │   ├── middleware/     # jwtAuth.js, rbac.js, cors.js
+│   │   ├── modules/        # 业务模块（预留 Phase 2）
+│   │   ├── seeds/          # RBAC 种子数据
+│   │   ├── db.js           # SQLite + better-sqlite3
+│   │   ├── auth.js         # 旧 session 认证
+│   │   └── index.js        # 双端口启动入口
+│   ├── db/                 # SQLite 文件
+│   ├── public/uploads/     # 上传图片
+│   └── .env                # 环境变量
+│
+├── admin/                  # Vue 3 + TypeScript 管理后台
+│   ├── src/
+│   │   ├── api/            # Axios 请求 + auth 接口
+│   │   ├── components/     # 布局组件
+│   │   ├── directives/     # v-permission
+│   │   ├── router/         # Vue Router + 路由守卫
+│   │   ├── stores/         # Pinia (auth, permission)
+│   │   └── views/          # 页面
+│   ├── scripts/            # 验收验证脚本
+│   └── vite.config.ts      # 代理 /api → localhost:3000
+│
+├── css/                    # 前台样式
+├── js/                     # 前台脚本
+├── *.html                  # 前台静态页面
+└── docs/                   # 架构设计 + 实施计划
+```
+
+---
+
+## 常用命令
+
+| 命令 | 作用 |
+|------|------|
+| `cd server && npm run dev` | 启动后端（双端口） |
+| `cd server && npm start` | 生产模式 |
+| `cd admin && npm run dev` | 启动 Vue dev server |
+| `cd admin && npm run build` | 构建生产包 |
+| `cd admin && npx tsx scripts/check-integration.ts` | Phase 1 集成验收 |
+
+---
+
+## 技术栈
+
+- **后端**: Express 5, better-sqlite3, jsonwebtoken, bcryptjs, multer, helmet
+- **前台**: 原生 HTML/JS, CSS 自定义属性（11 主题）
+- **后台**: Vue 3.5, Vite 8, TypeScript, Naive UI 2.44, Pinia 3, Vue Router 5
+- **部署**: Docker, bash deploy.sh
+
+---
+
+## 文档
+
+- [CLAUDE.md](CLAUDE.md) — 给 Claude Code 的上下文指南
+- [docs/04-admin-architecture.md](docs/04-admin-architecture.md) — 架构设计
+- [docs/05-implementation-plan.md](docs/05-implementation-plan.md) — 实施计划
+- [CHANGELOG.md](CHANGELOG.md) — 版本变更记录


### PR DESCRIPTION
## Summary
- Rewrite CLAUDE.md with dual-port architecture, JWT/RBAC, Vue 3 SPA modules, and verifier script inventory.
- Add README.md: 5-minute quick-start, project structure, command cheat-sheet.
- Add CHANGELOG.md: Phase 1 (T1.1–T1.26) change summary with Phase 2–5 roadmap.

Closes #30