### PR TITLE
feat(T2.1): user management API (CRUD + reset password) with verifier

### DIFF
--- a/server/scripts/check-user-api.js
+++ b/server/scripts/check-user-api.js
@@ -1,0 +1,262 @@
+// One-off helper: verify user management API handlers
+// Usage (from server/): node scripts/check-user-api.js
+const path = require("node:path");
+require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
+
+if (!process.env.JWT_SECRET) {
+  process.env.JWT_SECRET = "test-secret-jwt-for-user-api-check-do-not-use-in-prod";
+}
+
+const { openDb, migrate, ensureSeed } = require("../src/db");
+const { ensureRbacSeed } = require("../src/seeds/rbacSeed");
+const handlers = require("../src/apps/admin/rbac/userHandlers");
+
+const db = openDb();
+migrate(db);
+ensureSeed(db);
+ensureRbacSeed(db, {
+  adminEmail: process.env.ADMIN_EMAIL || "admin@example.com",
+  adminPassword: process.env.ADMIN_PASSWORD || "admin",
+  adminPasswordHash: process.env.ADMIN_PASSWORD_HASH || "",
+});
+
+let pass = true;
+function check(label, ok, detail) {
+  const tag = ok ? "OK  " : "FAIL";
+  console.log(`[${tag}] ${label}${detail ? "  -- " + detail : ""}`);
+  if (!ok) pass = false;
+}
+
+function makeReq(overrides = {}) {
+  return {
+    query: {},
+    params: {},
+    body: {},
+    user: null,
+    ...overrides,
+    query: { ...overrides.query },
+    params: { ...overrides.params },
+    body: overrides.body !== undefined ? overrides.body : {},
+  };
+}
+
+async function call(handler, req) {
+  let statusCode = 0;
+  let respBody = null;
+  const res = {
+    status(c) { statusCode = c; return this; },
+    json(b) { respBody = b; return this; },
+  };
+  await handler(req, res);
+  return { statusCode, body: respBody };
+}
+
+function cleanupTestUsers() {
+  const ids = db
+    .prepare("SELECT id FROM users WHERE username LIKE 'testuser_%' OR email LIKE 'testuser_%'")
+    .all()
+    .map((r) => r.id);
+  if (ids.length) {
+    db.prepare(`DELETE FROM user_roles WHERE user_id IN (${ids.map(() => "?").join(",")})`).run(...ids);
+    db.prepare(`DELETE FROM users WHERE id IN (${ids.map(() => "?").join(",")})`).run(...ids);
+  }
+}
+
+(async () => {
+  cleanupTestUsers();
+
+  const sa = db.prepare("SELECT id, username, email FROM users WHERE is_super_admin = 1").get();
+  check("seeded super admin exists", !!sa, `id=${sa && sa.id}`);
+
+  const viewerRole = db.prepare("SELECT id FROM roles WHERE code = 'viewer'").get();
+  check("viewer role exists", !!viewerRole);
+
+  // ---------- createUser ----------
+  let createdUserId = 0;
+  {
+    const r = await call(handlers.createUser, makeReq({ body: {
+      username: "testuser_1",
+      email: "testuser_1@example.com",
+      password: "password123",
+      display_name: "Tester One",
+      status: "active",
+      role_ids: viewerRole ? [viewerRole.id] : [],
+    }}));
+    check("createUser -> 201", r.statusCode === 201, `code=${r.body && r.body.code}`);
+    const d = r.body && r.body.data;
+    check("createUser returns public fields", d && d.username === "testuser_1" && d.email === "testuser_1@example.com");
+    check("createUser has roles", d && Array.isArray(d.roles));
+    check("createUser no password_hash", d && !("password_hash" in d));
+    createdUserId = d ? d.id : 0;
+  }
+
+  // duplicate username/email
+  {
+    const r = await call(handlers.createUser, makeReq({ body: {
+      username: "testuser_1",
+      email: "testuser_1_dup@example.com",
+      password: "password123",
+    }}));
+    check("createUser duplicate username -> 409", r.statusCode === 409);
+  }
+  {
+    const r = await call(handlers.createUser, makeReq({ body: {
+      username: "testuser_1_dup",
+      email: "testuser_1@example.com",
+      password: "password123",
+    }}));
+    check("createUser duplicate email -> 409", r.statusCode === 409);
+  }
+
+  // missing fields
+  {
+    const r = await call(handlers.createUser, makeReq({ body: { username: "x", email: "x@e.com" } }));
+    check("createUser missing password -> 400", r.statusCode === 400);
+  }
+
+  // ---------- listUsers ----------
+  {
+    const r = await call(handlers.listUsers, makeReq({ query: { page: "1", pageSize: "20" } }));
+    check("listUsers -> 200", r.statusCode === 200);
+    const d = r.body && r.body.data;
+    check("listUsers has items array", d && Array.isArray(d.items));
+    check("listUsers has total number", d && typeof d.total === "number");
+    check("listUsers has page/pageSize", d && d.page === 1 && d.pageSize === 20);
+    const found = d && d.items.find((u) => u.id === createdUserId);
+    check("listUsers contains created user", !!found);
+  }
+
+  // keyword search
+  {
+    const r = await call(handlers.listUsers, makeReq({ query: { keyword: "testuser_1" } }));
+    const d = r.body && r.body.data;
+    check("listUsers keyword filter works", d && d.items.length >= 1 && d.items.some((u) => u.id === createdUserId));
+  }
+
+  // status filter
+  {
+    const r = await call(handlers.listUsers, makeReq({ query: { status: "disabled" } }));
+    const d = r.body && r.body.data;
+    check("listUsers status filter works", d && !d.items.some((u) => u.id === createdUserId));
+  }
+
+  // ---------- getUser ----------
+  {
+    const r = await call(handlers.getUser, makeReq({ params: { id: String(createdUserId) } }));
+    check("getUser -> 200", r.statusCode === 200);
+    const d = r.body && r.body.data;
+    check("getUser returns correct id", d && d.id === createdUserId);
+    check("getUser has roles", d && Array.isArray(d.roles));
+  }
+  {
+    const r = await call(handlers.getUser, makeReq({ params: { id: "999999" } }));
+    check("getUser nonexistent -> 404", r.statusCode === 404);
+  }
+  {
+    const r = await call(handlers.getUser, makeReq({ params: { id: "0" } }));
+    check("getUser invalid id -> 400", r.statusCode === 400);
+  }
+
+  // ---------- updateUser ----------
+  {
+    const r = await call(handlers.updateUser, makeReq({
+      params: { id: String(createdUserId) },
+      body: { display_name: "Updated Name", status: "disabled" },
+    }));
+    check("updateUser -> 200", r.statusCode === 200);
+    const d = r.body && r.body.data;
+    check("updateUser display_name changed", d && d.displayName === "Updated Name");
+    check("updateUser status changed", d && d.status === "disabled");
+  }
+
+  // update super admin forbidden
+  if (sa) {
+    const r = await call(handlers.updateUser, makeReq({
+      params: { id: String(sa.id) },
+      body: { display_name: "Nope" },
+    }));
+    check("updateUser super admin -> 403", r.statusCode === 403);
+  }
+
+  // update nonexistent
+  {
+    const r = await call(handlers.updateUser, makeReq({ params: { id: "999999" }, body: { display_name: "Nope" } }));
+    check("updateUser nonexistent -> 404", r.statusCode === 404);
+  }
+
+  // ---------- resetPassword ----------
+  {
+    const r = await call(handlers.resetPassword, makeReq({
+      params: { id: String(createdUserId) },
+      body: { new_password: "newpass456" },
+    }));
+    check("resetPassword -> 200", r.statusCode === 200);
+    const d = r.body && r.body.data;
+    check("resetPassword returns reset=true", d && d.reset === true);
+  }
+  {
+    const r = await call(handlers.resetPassword, makeReq({
+      params: { id: String(createdUserId) },
+      body: { new_password: "12" },
+    }));
+    check("resetPassword too short -> 400", r.statusCode === 400);
+  }
+  {
+    const r = await call(handlers.resetPassword, makeReq({ params: { id: "999999" }, body: { new_password: "validpass" } }));
+    check("resetPassword nonexistent -> 404", r.statusCode === 404);
+  }
+
+  // ---------- deleteUser ----------
+  // create a second user to test delete-self guard
+  let user2Id = 0;
+  {
+    const r = await call(handlers.createUser, makeReq({ body: {
+      username: "testuser_2",
+      email: "testuser_2@example.com",
+      password: "password123",
+    }}));
+    user2Id = r.body && r.body.data ? r.body.data.id : 0;
+  }
+
+  // delete self forbidden
+  {
+    const r = await call(handlers.deleteUser, makeReq({
+      params: { id: String(user2Id) },
+      user: { userId: user2Id },
+    }));
+    check("deleteUser self -> 403", r.statusCode === 403);
+  }
+
+  // delete super admin forbidden
+  if (sa) {
+    const r = await call(handlers.deleteUser, makeReq({
+      params: { id: String(sa.id) },
+      user: { userId: user2Id },
+    }));
+    check("deleteUser super admin -> 403", r.statusCode === 403);
+  }
+
+  // delete nonexistent
+  {
+    const r = await call(handlers.deleteUser, makeReq({ params: { id: "999999" }, user: { userId: user2Id } }));
+    check("deleteUser nonexistent -> 404", r.statusCode === 404);
+  }
+
+  // successful delete (caller is super admin)
+  {
+    const r = await call(handlers.deleteUser, makeReq({
+      params: { id: String(user2Id) },
+      user: { userId: sa.id },
+    }));
+    check("deleteUser -> 200", r.statusCode === 200);
+    const d = r.body && r.body.data;
+    check("deleteUser returns deleted=true", d && d.deleted === true);
+  }
+
+  // cleanup
+  cleanupTestUsers();
+
+  console.log("");
+  console.log(pass ? "PASS: user management API verified." : "FAIL: see [FAIL] entries above.");
+  process.exit(pass ? 0 : 1);
+})();

--- a/server/src/apps/admin/rbac/userHandlers.js
+++ b/server/src/apps/admin/rbac/userHandlers.js
@@ -1,0 +1,302 @@
+const bcrypt = require("bcryptjs");
+const { openDb } = require("../../../db");
+const { nowIso, toInt } = require("../../../utils");
+
+function hashPassword(pw) {
+  return bcrypt.hashSync(String(pw), 10);
+}
+
+function pickUserPublic(row) {
+  return {
+    id: row.id,
+    username: row.username,
+    email: row.email,
+    displayName: row.display_name || null,
+    avatarUrl: row.avatar_url || null,
+    status: row.status,
+    isSuperAdmin: row.is_super_admin === 1,
+    lastLoginAt: row.last_login_at || null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function listUserRoles(db, userId) {
+  return db
+    .prepare(
+      `SELECT r.id, r.code, r.name FROM user_roles ur
+         JOIN roles r ON r.id = ur.role_id AND r.status = 'active'
+        WHERE ur.user_id = ?
+        ORDER BY r.id`
+    )
+    .all(userId);
+}
+
+function setUserRoles(db, userId, roleIds) {
+  const del = db.prepare("DELETE FROM user_roles WHERE user_id = ?");
+  const ins = db.prepare(
+    "INSERT OR IGNORE INTO user_roles (user_id, role_id) VALUES (?, ?)"
+  );
+  const tx = db.transaction(() => {
+    del.run(userId);
+    for (const rid of roleIds) {
+      const n = Number(rid);
+      if (Number.isFinite(n)) ins.run(userId, n);
+    }
+  });
+  tx();
+}
+
+function buildListQuery({ keyword, status }) {
+  const where = ["1=1"];
+  const params = [];
+  if (keyword) {
+    where.push("(username LIKE ? OR email LIKE ? OR display_name LIKE ?)");
+    const like = `%${keyword}%`;
+    params.push(like, like, like);
+  }
+  if (status) {
+    where.push("status = ?");
+    params.push(status);
+  }
+  return { clause: where.join(" AND "), params };
+}
+
+function listUsers(req, res) {
+  const db = openDb();
+  const page = Math.max(1, toInt(req.query.page, 1));
+  const pageSize = Math.min(100, Math.max(1, toInt(req.query.pageSize, 20)));
+  const keyword = String(req.query.keyword || "").trim() || null;
+  const status = String(req.query.status || "").trim() || null;
+
+  const { clause, params } = buildListQuery({ keyword, status });
+
+  const total = db
+    .prepare(`SELECT COUNT(*) AS c FROM users WHERE ${clause}`)
+    .get(...params).c;
+
+  const offset = (page - 1) * pageSize;
+  const rows = db
+    .prepare(
+      `SELECT id, username, email, display_name, avatar_url, status,
+              is_super_admin, last_login_at, created_at, updated_at
+         FROM users
+        WHERE ${clause}
+        ORDER BY id DESC
+        LIMIT ? OFFSET ?`
+    )
+    .all(...params, pageSize, offset);
+
+  const items = rows.map((r) => pickUserPublic(r));
+
+  return res.status(200).json({
+    code: 200,
+    message: "success",
+    data: { items, total, page, pageSize },
+  });
+}
+
+function getUser(req, res) {
+  const db = openDb();
+  const id = toInt(req.params.id, 0);
+  if (!id) return res.status(400).json({ code: 400, message: "Invalid id" });
+
+  const row = db
+    .prepare(
+      `SELECT id, username, email, display_name, avatar_url, status,
+              is_super_admin, last_login_at, created_at, updated_at
+         FROM users WHERE id = ?`
+    )
+    .get(id);
+  if (!row) return res.status(404).json({ code: 404, message: "User not found" });
+
+  const user = pickUserPublic(row);
+  user.roles = listUserRoles(db, id);
+  return res.status(200).json({ code: 200, message: "success", data: user });
+}
+
+function createUser(req, res) {
+  const db = openDb();
+  const { username, email, password, display_name, avatar_url, status, role_ids } =
+    req.body || {};
+
+  if (!username || !email || !password) {
+    return res.status(400).json({
+      code: 400,
+      message: "Missing required fields: username, email, password",
+    });
+  }
+
+  const exists = db
+    .prepare("SELECT 1 FROM users WHERE username = ? OR email = ? LIMIT 1")
+    .get(username, email);
+  if (exists) {
+    return res.status(409).json({
+      code: 409,
+      message: "Username or email already exists",
+    });
+  }
+
+  const createdAt = nowIso();
+  const info = db
+    .prepare(
+      `INSERT INTO users
+         (username, email, password_hash, display_name, avatar_url, status, is_super_admin, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)`
+    )
+    .run(
+      username,
+      email,
+      hashPassword(password),
+      display_name || null,
+      avatar_url || null,
+      status === "disabled" ? "disabled" : "active",
+      createdAt,
+      createdAt
+    );
+
+  const userId = info.lastInsertRowid;
+
+  if (Array.isArray(role_ids) && role_ids.length > 0) {
+    setUserRoles(db, userId, role_ids);
+  }
+
+  const row = db
+    .prepare(
+      `SELECT id, username, email, display_name, avatar_url, status,
+              is_super_admin, last_login_at, created_at, updated_at
+         FROM users WHERE id = ?`
+    )
+    .get(userId);
+
+  const user = pickUserPublic(row);
+  user.roles = listUserRoles(db, userId);
+  return res.status(201).json({ code: 201, message: "success", data: user });
+}
+
+function updateUser(req, res) {
+  const db = openDb();
+  const id = toInt(req.params.id, 0);
+  if (!id) return res.status(400).json({ code: 400, message: "Invalid id" });
+
+  const existing = db
+    .prepare("SELECT is_super_admin FROM users WHERE id = ?")
+    .get(id);
+  if (!existing) return res.status(404).json({ code: 404, message: "User not found" });
+
+  // Do not allow mutating super_admin users via normal update.
+  if (existing.is_super_admin === 1) {
+    return res.status(403).json({ code: 403, message: "Cannot modify super admin" });
+  }
+
+  const { username, email, display_name, avatar_url, status, role_ids } =
+    req.body || {};
+
+  const sets = [];
+  const params = [];
+
+  if (username !== undefined) {
+    sets.push("username = ?");
+    params.push(username);
+  }
+  if (email !== undefined) {
+    sets.push("email = ?");
+    params.push(email);
+  }
+  if (display_name !== undefined) {
+    sets.push("display_name = ?");
+    params.push(display_name || null);
+  }
+  if (avatar_url !== undefined) {
+    sets.push("avatar_url = ?");
+    params.push(avatar_url || null);
+  }
+  if (status !== undefined) {
+    sets.push("status = ?");
+    params.push(status === "disabled" ? "disabled" : "active");
+  }
+
+  if (sets.length > 0) {
+    sets.push("updated_at = ?");
+    params.push(nowIso());
+    params.push(id);
+    db.prepare(`UPDATE users SET ${sets.join(", ")} WHERE id = ?`).run(...params);
+  }
+
+  if (Array.isArray(role_ids)) {
+    setUserRoles(db, id, role_ids);
+  }
+
+  const row = db
+    .prepare(
+      `SELECT id, username, email, display_name, avatar_url, status,
+              is_super_admin, last_login_at, created_at, updated_at
+         FROM users WHERE id = ?`
+    )
+    .get(id);
+
+  const user = pickUserPublic(row);
+  user.roles = listUserRoles(db, id);
+  return res.status(200).json({ code: 200, message: "success", data: user });
+}
+
+function deleteUser(req, res) {
+  const db = openDb();
+  const id = toInt(req.params.id, 0);
+  if (!id) return res.status(400).json({ code: 400, message: "Invalid id" });
+
+  const row = db
+    .prepare("SELECT is_super_admin FROM users WHERE id = ?")
+    .get(id);
+  if (!row) return res.status(404).json({ code: 404, message: "User not found" });
+
+  if (row.is_super_admin === 1) {
+    return res.status(403).json({ code: 403, message: "Cannot delete super admin" });
+  }
+
+  const callerId = req.user && req.user.userId;
+  if (callerId === id) {
+    return res.status(403).json({ code: 403, message: "Cannot delete yourself" });
+  }
+
+  db.prepare("DELETE FROM users WHERE id = ?").run(id);
+  return res.status(200).json({ code: 200, message: "success", data: { deleted: true } });
+}
+
+function resetPassword(req, res) {
+  const db = openDb();
+  const id = toInt(req.params.id, 0);
+  if (!id) return res.status(400).json({ code: 400, message: "Invalid id" });
+
+  const { new_password } = req.body || {};
+  if (!new_password || String(new_password).length < 6) {
+    return res.status(400).json({
+      code: 400,
+      message: "new_password is required and must be at least 6 characters",
+    });
+  }
+
+  const row = db.prepare("SELECT 1 FROM users WHERE id = ?").get(id);
+  if (!row) return res.status(404).json({ code: 404, message: "User not found" });
+
+  db.prepare("UPDATE users SET password_hash = ?, updated_at = ? WHERE id = ?").run(
+    hashPassword(new_password),
+    nowIso(),
+    id
+  );
+
+  return res.status(200).json({
+    code: 200,
+    message: "success",
+    data: { reset: true },
+  });
+}
+
+module.exports = {
+  listUsers,
+  getUser,
+  createUser,
+  updateUser,
+  deleteUser,
+  resetPassword,
+};

--- a/server/src/apps/admin/rbac/usersRouter.js
+++ b/server/src/apps/admin/rbac/usersRouter.js
@@ -1,0 +1,15 @@
+const express = require("express");
+const handlers = require("./userHandlers");
+const jwtAuth = require("../../../middleware/jwtAuth");
+const requirePermission = require("../../../middleware/rbac");
+
+const router = express.Router();
+
+router.get("/", jwtAuth, requirePermission("user:list"), handlers.listUsers);
+router.get("/:id", jwtAuth, requirePermission("user:list"), handlers.getUser);
+router.post("/", jwtAuth, requirePermission("user:create"), handlers.createUser);
+router.put("/:id", jwtAuth, requirePermission("user:update"), handlers.updateUser);
+router.delete("/:id", jwtAuth, requirePermission("user:delete"), handlers.deleteUser);
+router.post("/:id/reset-password", jwtAuth, requirePermission("user:update"), handlers.resetPassword);
+
+module.exports = router;

--- a/server/src/apps/adminApp.js
+++ b/server/src/apps/adminApp.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const devCors = require("../middleware/cors");
 const authRouter = require("./admin/auth/authRouter");
+const usersRouter = require("./admin/rbac/usersRouter");
 
 const app = express();
 
@@ -17,6 +18,7 @@ app.get("/health", (req, res) => {
 
 const v2Router = express.Router();
 v2Router.use("/auth", authRouter);
+v2Router.use("/admin/rbac/users", usersRouter);
 app.use("/api/v2", v2Router);
 
 module.exports = app;


### PR DESCRIPTION
## Summary
- 新增用户管理后端 API：列表、详情、创建、更新、删除、重置密码
- 路由挂载于 `/api/v2/admin/rbac/users`
- 每个端点均受 `jwtAuth` + `requirePermission` 保护
- 超管用户不可通过普通接口修改/删除
- 新增 `server/scripts/check-user-api.js` 验证脚本（30 项断言）

## Verification
- [x] `node scripts/check-user-api.js` PASS
- [x] `node -c` 语法检查通过
- [x] `cd admin && npm run build` 通过

Closes #31