### PR TITLE
feat(cms): T2.8 posts CRUD API

### DIFF
--- a/server/scripts/check-cms-posts-api.js
+++ b/server/scripts/check-cms-posts-api.js
@@ -1,0 +1,241 @@
+// One-off helper: verify CMS posts API handlers
+// Usage (from server/): node scripts/check-cms-posts-api.js
+const path = require("node:path");
+require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
+
+if (!process.env.JWT_SECRET) {
+  process.env.JWT_SECRET = "test-secret-jwt-for-cms-posts-check-do-not-use-in-prod";
+}
+
+const { openDb, migrate, ensureSeed } = require("../src/db");
+const { ensureRbacSeed } = require("../src/seeds/rbacSeed");
+const handlers = require("../src/apps/admin/cms/postHandlers");
+
+const db = openDb();
+migrate(db);
+ensureSeed(db);
+ensureRbacSeed(db, {
+  adminEmail: process.env.ADMIN_EMAIL || "admin@example.com",
+  adminPassword: process.env.ADMIN_PASSWORD || "admin",
+  adminPasswordHash: process.env.ADMIN_PASSWORD_HASH || "",
+});
+
+let pass = true;
+function check(label, ok, detail) {
+  const tag = ok ? "OK  " : "FAIL";
+  console.log(`[${tag}] ${label}${detail ? "  -- " + detail : ""}`);
+  if (!ok) pass = false;
+}
+
+function makeReq(overrides = {}) {
+  return {
+    query: {},
+    params: {},
+    body: {},
+    user: null,
+    ...overrides,
+    query: { ...overrides.query },
+    params: { ...overrides.params },
+    body: overrides.body !== undefined ? overrides.body : {},
+  };
+}
+
+async function call(handler, req) {
+  let statusCode = 0;
+  let respBody = null;
+  const res = {
+    status(c) { statusCode = c; return this; },
+    json(b) { respBody = b; return this; },
+  };
+  await handler(req, res);
+  return { statusCode, body: respBody };
+}
+
+function cleanupTestPosts() {
+  const ids = db
+    .prepare("SELECT id FROM posts WHERE slug LIKE 'testpost-%' OR title LIKE 'testpost_%'")
+    .all()
+    .map((r) => r.id);
+  if (ids.length) {
+    const ph = ids.map(() => "?").join(",");
+    db.prepare(`DELETE FROM post_tags WHERE postId IN (${ph})`).run(...ids);
+    db.prepare(`DELETE FROM post_categories WHERE postId IN (${ph})`).run(...ids);
+    db.prepare(`DELETE FROM posts WHERE id IN (${ph})`).run(...ids);
+  }
+  // Clean test tags / categories
+  db.prepare("DELETE FROM tags WHERE slug LIKE 'testtag-%'").run();
+  db.prepare("DELETE FROM categories WHERE slug LIKE 'testcat-%'").run();
+}
+
+(async () => {
+  cleanupTestPosts();
+
+  let createdId = 0;
+  // ---------- createPost ----------
+  {
+    const r = await call(handlers.createPost, makeReq({ body: {
+      title: "testpost_1",
+      slug: "testpost-one",
+      contentMarkdown: "# Hello",
+      excerpt: "intro",
+      tags: "testtag-a, testtag-b",
+      categories: "testcat-x",
+    }}));
+    check("createPost -> 201", r.statusCode === 201, `code=${r.body && r.body.code}`);
+    const d = r.body && r.body.data;
+    check("createPost returns id and slug", d && d.id > 0 && d.slug === "testpost-one");
+    check("createPost status default draft", d && d.status === "draft");
+    check("createPost no contentHtml leaked", d && !("contentHtml" in d));
+    check("createPost has tags array", d && Array.isArray(d.tags) && d.tags.length === 2);
+    check("createPost has categories array", d && Array.isArray(d.categories) && d.categories.length === 1);
+    createdId = d ? d.id : 0;
+  }
+
+  // create with status published -> publishedAt set
+  {
+    const r = await call(handlers.createPost, makeReq({ body: {
+      title: "testpost_2",
+      slug: "testpost-two",
+      contentMarkdown: "# Two",
+      status: "published",
+    }}));
+    const d = r.body && r.body.data;
+    check("createPost published sets publishedAt", d && d.status === "published" && !!d.publishedAt);
+  }
+
+  // duplicate slug -> 409
+  {
+    const r = await call(handlers.createPost, makeReq({ body: {
+      title: "testpost_dup",
+      slug: "testpost-one",
+      contentMarkdown: "# Dup",
+    }}));
+    check("createPost duplicate slug -> 409", r.statusCode === 409, `body=${JSON.stringify(r.body)}`);
+  }
+
+  // ---------- listPosts ----------
+  {
+    const r = await call(handlers.listPosts, makeReq({ query: { page: "1", pageSize: "10" } }));
+    check("listPosts -> 200", r.statusCode === 200);
+    const d = r.body && r.body.data;
+    check("listPosts has items array", d && Array.isArray(d.items));
+    check("listPosts has total/page/pageSize", d && typeof d.total === "number" && d.page === 1 && d.pageSize === 10);
+    const found = d && d.items.find((p) => p.id === createdId);
+    check("listPosts contains created post", !!found);
+    check("listPosts items have tags+categories", found && Array.isArray(found.tags) && Array.isArray(found.categories));
+  }
+
+  // keyword filter
+  {
+    const r = await call(handlers.listPosts, makeReq({ query: { keyword: "testpost_1" } }));
+    const d = r.body && r.body.data;
+    check("listPosts keyword filter works", d && d.items.length >= 1 && d.items.some((p) => p.id === createdId));
+  }
+
+  // status filter
+  {
+    const r = await call(handlers.listPosts, makeReq({ query: { status: "published" } }));
+    const d = r.body && r.body.data;
+    check("listPosts status filter -> only published", d && d.items.every((p) => p.status === "published"));
+  }
+
+  // ---------- getPost ----------
+  {
+    const r = await call(handlers.getPost, makeReq({ params: { id: String(createdId) } }));
+    check("getPost -> 200", r.statusCode === 200);
+    const d = r.body && r.body.data;
+    check("getPost has contentMarkdown", d && typeof d.contentMarkdown === "string");
+    check("getPost has tags+categories", d && Array.isArray(d.tags) && Array.isArray(d.categories));
+  }
+  {
+    const r = await call(handlers.getPost, makeReq({ params: { id: "0" } }));
+    check("getPost invalid id -> 400", r.statusCode === 400);
+  }
+  {
+    const r = await call(handlers.getPost, makeReq({ params: { id: "999999" } }));
+    check("getPost nonexistent -> 404", r.statusCode === 404);
+  }
+
+  // ---------- updatePost ----------
+  {
+    const r = await call(handlers.updatePost, makeReq({
+      params: { id: String(createdId) },
+      body: { title: "testpost_1_updated", excerpt: "new excerpt", tags: "testtag-c" },
+    }));
+    check("updatePost -> 200", r.statusCode === 200);
+    const d = r.body && r.body.data;
+    check("updatePost title changed", d && d.title === "testpost_1_updated");
+    check("updatePost excerpt changed", d && d.excerpt === "new excerpt");
+    check("updatePost tags reset to single", d && d.tags.length === 1);
+  }
+  {
+    const r = await call(handlers.updatePost, makeReq({
+      params: { id: String(createdId) },
+      body: { slug: "testpost-two" }, // collide with existing
+    }));
+    check("updatePost duplicate slug -> 409", r.statusCode === 409);
+  }
+  {
+    const r = await call(handlers.updatePost, makeReq({ params: { id: "999999" }, body: { title: "x" } }));
+    check("updatePost nonexistent -> 404", r.statusCode === 404);
+  }
+
+  // ---------- deletePost ----------
+  // create a third to delete
+  let toDelId = 0;
+  {
+    const r = await call(handlers.createPost, makeReq({ body: {
+      title: "testpost_3", slug: "testpost-three", contentMarkdown: "# T3",
+    }}));
+    toDelId = r.body && r.body.data ? r.body.data.id : 0;
+  }
+  {
+    const r = await call(handlers.deletePost, makeReq({ params: { id: String(toDelId) } }));
+    check("deletePost -> 200", r.statusCode === 200);
+    const d = r.body && r.body.data;
+    check("deletePost returns deleted=true", d && d.deleted === true);
+  }
+  {
+    const r = await call(handlers.deletePost, makeReq({ params: { id: "999999" } }));
+    check("deletePost nonexistent -> 404", r.statusCode === 404);
+  }
+
+  // ---------- performance: list 1000 posts < 200ms ----------
+  // seed 1000 testpost rows, then time a single listPosts call
+  {
+    const insertMany = db.prepare(`
+      INSERT INTO posts (title, slug, excerpt, coverImageUrl, contentMarkdown, contentHtml, status, publishedAt, createdAt, updatedAt)
+      VALUES (@title, @slug, @excerpt, NULL, @contentMarkdown, NULL, 'published', @publishedAt, @createdAt, @updatedAt)
+    `);
+    const now = new Date().toISOString();
+    const tx = db.transaction(() => {
+      for (let i = 0; i < 1000; i++) {
+        insertMany.run({
+          title: `testpost_perf_${i}`,
+          slug: `testpost-perf-${i}`,
+          excerpt: `excerpt ${i}`,
+          contentMarkdown: `# Post ${i}`,
+          publishedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+    });
+    tx();
+
+    const t0 = Date.now();
+    const r = await call(handlers.listPosts, makeReq({ query: { page: "1", pageSize: "20" } }));
+    const elapsed = Date.now() - t0;
+    check(`listPosts 1000 rows < 200ms (got ${elapsed}ms)`, r.statusCode === 200 && elapsed < 200);
+
+    // cleanup perf rows
+    db.prepare("DELETE FROM posts WHERE slug LIKE 'testpost-perf-%'").run();
+  }
+
+  // cleanup
+  cleanupTestPosts();
+
+  console.log("");
+  console.log(pass ? "PASS: CMS posts API verified." : "FAIL: see [FAIL] entries above.");
+  process.exit(pass ? 0 : 1);
+})();

--- a/server/src/apps/admin/cms/postHandlers.js
+++ b/server/src/apps/admin/cms/postHandlers.js
@@ -1,0 +1,230 @@
+const { openDb, listTagsForPost, listTagsForPosts, listCategoriesForPost, listCategoriesForPosts, setPostTags, setPostCategories } = require("../../../db");
+const { nowIso, toInt, normalizeSlug, splitTags } = require("../../../utils");
+
+function pickPostPublic(row) {
+  return {
+    id: row.id,
+    title: row.title,
+    slug: row.slug,
+    excerpt: row.excerpt || null,
+    coverImageUrl: row.coverImageUrl || null,
+    contentMarkdown: row.contentMarkdown,
+    status: row.status,
+    publishedAt: row.publishedAt || null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function pickPostListItem(row) {
+  return {
+    id: row.id,
+    title: row.title,
+    slug: row.slug,
+    excerpt: row.excerpt || null,
+    coverImageUrl: row.coverImageUrl || null,
+    status: row.status,
+    publishedAt: row.publishedAt || null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function buildListWhere({ keyword, status }) {
+  const where = ["1=1"];
+  const params = [];
+  if (keyword) {
+    where.push("(title LIKE ? OR slug LIKE ? OR excerpt LIKE ?)");
+    const like = `%${keyword}%`;
+    params.push(like, like, like);
+  }
+  if (status) {
+    where.push("status = ?");
+    params.push(status);
+  }
+  return { clause: where.join(" AND "), params };
+}
+
+function listPosts(req, res) {
+  const db = openDb();
+  const page = Math.max(1, toInt(req.query.page, 1));
+  const pageSize = Math.min(100, Math.max(1, toInt(req.query.pageSize, 20)));
+  const keyword = String(req.query.keyword || "").trim() || null;
+  const status = String(req.query.status || "").trim() || null;
+  const orderField = String(req.query.orderBy || "updatedAt");
+  const orderDir = String(req.query.order || "desc").toLowerCase() === "asc" ? "ASC" : "DESC";
+  const allowedOrders = new Set(["updatedAt", "createdAt", "publishedAt", "title", "id"]);
+  const orderCol = allowedOrders.has(orderField) ? orderField : "updatedAt";
+
+  const { clause, params } = buildListWhere({ keyword, status });
+  const total = db.prepare(`SELECT COUNT(*) AS c FROM posts WHERE ${clause}`).get(...params).c;
+
+  const offset = (page - 1) * pageSize;
+  const rows = db
+    .prepare(`
+      SELECT id, title, slug, excerpt, coverImageUrl, status, publishedAt, createdAt, updatedAt
+        FROM posts
+       WHERE ${clause}
+       ORDER BY ${orderCol} ${orderDir}, id DESC
+       LIMIT ? OFFSET ?
+    `)
+    .all(...params, pageSize, offset);
+
+  const ids = rows.map((r) => r.id);
+  const tagsMap = listTagsForPosts(db, ids);
+  const catsMap = listCategoriesForPosts(db, ids);
+
+  const items = rows.map((r) => ({
+    ...pickPostListItem(r),
+    tags: tagsMap[r.id] || [],
+    categories: catsMap[r.id] || [],
+  }));
+
+  return res.status(200).json({
+    code: 200,
+    message: "success",
+    data: { items, total, page, pageSize },
+  });
+}
+
+function getPost(req, res) {
+  const db = openDb();
+  const id = toInt(req.params.id, 0);
+  if (!id) return res.status(400).json({ code: 400, message: "Invalid id" });
+
+  const row = db
+    .prepare(`
+      SELECT id, title, slug, excerpt, coverImageUrl, contentMarkdown, status, publishedAt, createdAt, updatedAt
+        FROM posts WHERE id = ?
+    `)
+    .get(id);
+  if (!row) return res.status(404).json({ code: 404, message: "Post not found" });
+
+  const data = pickPostPublic(row);
+  data.tags = listTagsForPost(db, id);
+  data.categories = listCategoriesForPost(db, id);
+  return res.status(200).json({ code: 200, message: "success", data });
+}
+
+function createPost(req, res) {
+  const db = openDb();
+  const body = req.body || {};
+  const title = String(body.title ?? "").trim() || "未命名文章";
+  const slug = normalizeSlug(body.slug || title || nowIso());
+  const excerpt = String(body.excerpt ?? "").trim() || null;
+  const coverImageUrl = String(body.coverImageUrl ?? "").trim() || null;
+  const contentMarkdown = String(body.contentMarkdown ?? "").trim() || "";
+  const status = String(body.status ?? "draft") === "published" ? "published" : "draft";
+  const createdAt = nowIso();
+  const updatedAt = createdAt;
+  const publishedAt = status === "published" ? createdAt : null;
+
+  try {
+    const info = db
+      .prepare(`
+        INSERT INTO posts (title, slug, excerpt, coverImageUrl, contentMarkdown, contentHtml, status, publishedAt, createdAt, updatedAt)
+        VALUES (@title, @slug, @excerpt, @coverImageUrl, @contentMarkdown, NULL, @status, @publishedAt, @createdAt, @updatedAt)
+      `)
+      .run({ title, slug, excerpt, coverImageUrl, contentMarkdown, status, publishedAt, createdAt, updatedAt });
+
+    const tagNames = splitTags(body.tags);
+    setPostTags(db, info.lastInsertRowid, tagNames);
+    const categoryNames = splitTags(body.categories || "");
+    setPostCategories(db, info.lastInsertRowid, categoryNames);
+
+    const row = db
+      .prepare(`
+        SELECT id, title, slug, excerpt, coverImageUrl, contentMarkdown, status, publishedAt, createdAt, updatedAt
+          FROM posts WHERE id = ?
+      `)
+      .get(info.lastInsertRowid);
+
+    const data = pickPostPublic(row);
+    data.tags = listTagsForPost(db, info.lastInsertRowid);
+    data.categories = listCategoriesForPost(db, info.lastInsertRowid);
+    return res.status(201).json({ code: 201, message: "success", data });
+  } catch (e) {
+    const msg = String(e.message || "");
+    if (msg.includes("UNIQUE") && msg.includes("posts.slug")) {
+      return res.status(409).json({ code: 409, message: "slug_taken" });
+    }
+    return res.status(500).json({ code: 500, message: "server_error" });
+  }
+}
+
+function updatePost(req, res) {
+  const db = openDb();
+  const id = toInt(req.params.id, 0);
+  if (!id) return res.status(400).json({ code: 400, message: "Invalid id" });
+
+  const existing = db
+    .prepare(`
+      SELECT id, title, slug, excerpt, coverImageUrl, contentMarkdown, status, publishedAt, createdAt, updatedAt
+        FROM posts WHERE id = ?
+    `)
+    .get(id);
+  if (!existing) return res.status(404).json({ code: 404, message: "Post not found" });
+
+  const body = req.body || {};
+  const title = String(body.title ?? existing.title).trim() || existing.title;
+  const slug = normalizeSlug(body.slug ?? existing.slug) || existing.slug;
+  const excerpt = body.excerpt !== undefined ? (String(body.excerpt).trim() || null) : existing.excerpt;
+  const coverImageUrl = body.coverImageUrl !== undefined ? (String(body.coverImageUrl).trim() || null) : existing.coverImageUrl;
+  const contentMarkdown = body.contentMarkdown !== undefined ? String(body.contentMarkdown) : existing.contentMarkdown;
+  const updatedAt = nowIso();
+
+  try {
+    db.prepare(`
+      UPDATE posts
+         SET title=@title, slug=@slug, excerpt=@excerpt, coverImageUrl=@coverImageUrl,
+             contentMarkdown=@contentMarkdown, contentHtml=NULL, updatedAt=@updatedAt
+       WHERE id=@id
+    `).run({ id, title, slug, excerpt, coverImageUrl, contentMarkdown, updatedAt });
+
+    if (body.tags !== undefined) {
+      setPostTags(db, id, splitTags(body.tags));
+    }
+    if (body.categories !== undefined) {
+      setPostCategories(db, id, splitTags(body.categories));
+    }
+
+    const row = db
+      .prepare(`
+        SELECT id, title, slug, excerpt, coverImageUrl, contentMarkdown, status, publishedAt, createdAt, updatedAt
+          FROM posts WHERE id = ?
+      `)
+      .get(id);
+
+    const data = pickPostPublic(row);
+    data.tags = listTagsForPost(db, id);
+    data.categories = listCategoriesForPost(db, id);
+    return res.status(200).json({ code: 200, message: "success", data });
+  } catch (e) {
+    const msg = String(e.message || "");
+    if (msg.includes("UNIQUE") && msg.includes("posts.slug")) {
+      return res.status(409).json({ code: 409, message: "slug_taken" });
+    }
+    return res.status(500).json({ code: 500, message: "server_error" });
+  }
+}
+
+function deletePost(req, res) {
+  const db = openDb();
+  const id = toInt(req.params.id, 0);
+  if (!id) return res.status(400).json({ code: 400, message: "Invalid id" });
+
+  const info = db.prepare(`DELETE FROM posts WHERE id = ?`).run(id);
+  if (info.changes === 0) return res.status(404).json({ code: 404, message: "Post not found" });
+  return res.status(200).json({ code: 200, message: "success", data: { deleted: true } });
+}
+
+// TODO(T2.8): contentHtml 仍然 lazy-render；前端编辑页若需要可加 ?withHtml=1 参数。
+// TODO(T2.8): 暂未实现批量删除/发布；如需 bulk ops 后续追加 POST /bulk 路由。
+
+module.exports = {
+  listPosts,
+  getPost,
+  createPost,
+  updatePost,
+  deletePost,
+};

--- a/server/src/apps/admin/cms/postsRouter.js
+++ b/server/src/apps/admin/cms/postsRouter.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const handlers = require("./postHandlers");
+const jwtAuth = require("../../../middleware/jwtAuth");
+const requirePermission = require("../../../middleware/rbac");
+
+const router = express.Router();
+
+router.get("/", jwtAuth, requirePermission("post:list"), handlers.listPosts);
+router.get("/:id", jwtAuth, requirePermission("post:list"), handlers.getPost);
+router.post("/", jwtAuth, requirePermission("post:create"), handlers.createPost);
+router.put("/:id", jwtAuth, requirePermission("post:update"), handlers.updatePost);
+router.delete("/:id", jwtAuth, requirePermission("post:delete"), handlers.deletePost);
+
+module.exports = router;

--- a/server/src/apps/adminApp.js
+++ b/server/src/apps/adminApp.js
@@ -6,6 +6,7 @@ const usersRouter = require("./admin/rbac/usersRouter");
 const rolesRouter = require("./admin/rbac/rolesRouter");
 const permissionsRouter = require("./admin/rbac/permissionsRouter");
 const menusRouter = require("./admin/rbac/menusRouter");
+const postsRouter = require("./admin/cms/postsRouter");
 
 const app = express();
 
@@ -27,6 +28,7 @@ v2Router.use("/admin/rbac/users", usersRouter);
 v2Router.use("/admin/rbac/roles", rolesRouter);
 v2Router.use("/admin/rbac/permissions", permissionsRouter);
 v2Router.use("/admin/rbac/menus", menusRouter);
+v2Router.use("/admin/cms/posts", postsRouter);
 app.use("/api/v2", v2Router);
 
 module.exports = app;


### PR DESCRIPTION
## Summary

Phase 2 §5.1.2 — first PR of the CMS backend integration. Lifts post CRUD from the legacy session-auth `/api/admin/posts` (frontApp port 8787) to the new JWT+RBAC `/api/v2/admin/cms/posts` (adminApp port 3000), so the upcoming Vue 3 SPA can talk to the v2 API directly.

- 5 new endpoints, all gated by `jwtAuth + requirePermission(post:*)`
- Response envelope `{code, message, data}`, HTTP status === code
- List handler batches tags + categories with single IN queries (no N+1)
- 1000-row list perf verified at < 200 ms (verifier reported 1 ms in dev)

## New / Modified Files

- 🆕 `server/src/apps/admin/cms/postHandlers.js`
- 🆕 `server/src/apps/admin/cms/postsRouter.js`
- 🆕 `server/scripts/check-cms-posts-api.js`
- ✏️ `server/src/apps/adminApp.js` (mount `/admin/cms/posts`)

## Routes

| Method | Path | Permission |
|---|---|---|
| GET | `/api/v2/admin/cms/posts` | `post:list` |
| GET | `/api/v2/admin/cms/posts/:id` | `post:list` |
| POST | `/api/v2/admin/cms/posts` | `post:create` |
| PUT | `/api/v2/admin/cms/posts/:id` | `post:update` |
| DELETE | `/api/v2/admin/cms/posts/:id` | `post:delete` |

## Permission Codes

No new codes — `post:list/create/update/delete/publish` are already in the RBAC seed (T1.4).

## Verification

```
$ node scripts/check-cms-posts-api.js
[OK  ] createPost -> 201 ... (30 checks)
[OK  ] listPosts 1000 rows < 200ms (got 1ms)
PASS: CMS posts API verified.
```

## Edge Cases / TODO

- `// TODO(T2.8)` contentHtml stays lazy-rendered; if SPA editor needs HTML, add `?withHtml=1`
- `// TODO(T2.8)` no bulk delete/publish endpoints yet — defer until SPA needs them
- Audit logger (T2.7) auto-captures every non-GET on these routes; no manual integration

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)