### PR TITLE
feat(cms): T2.9 posts publish/unpublish API

### DIFF
--- a/server/scripts/check-cms-posts-api.js
+++ b/server/scripts/check-cms-posts-api.js
@@ -200,6 +200,48 @@ function cleanupTestPosts() {
     check("deletePost nonexistent -> 404", r.statusCode === 404);
   }
 
+  // ---------- publishPost / unpublishPost ----------
+  let pubId = 0;
+  {
+    const r = await call(handlers.createPost, makeReq({ body: {
+      title: "testpost_pub", slug: "testpost-pub", contentMarkdown: "# Pub",
+    }}));
+    pubId = r.body && r.body.data ? r.body.data.id : 0;
+    check("createPost (for publish test) default draft", r.body && r.body.data && r.body.data.status === "draft");
+  }
+  {
+    const r = await call(handlers.publishPost, makeReq({ params: { id: String(pubId) } }));
+    check("publishPost -> 200", r.statusCode === 200);
+    const d = r.body && r.body.data;
+    check("publishPost returns status=published", d && d.status === "published");
+    check("publishPost returns publishedAt", d && !!d.publishedAt);
+    // verify DB
+    const row = db.prepare("SELECT status, publishedAt FROM posts WHERE id=?").get(pubId);
+    check("publishPost DB row status=published", row && row.status === "published" && !!row.publishedAt);
+  }
+  {
+    const r = await call(handlers.unpublishPost, makeReq({ params: { id: String(pubId) } }));
+    check("unpublishPost -> 200", r.statusCode === 200);
+    const d = r.body && r.body.data;
+    check("unpublishPost returns status=draft", d && d.status === "draft");
+    // verify DB: status reverted, publishedAt KEPT (legacy parity)
+    const row = db.prepare("SELECT status, publishedAt FROM posts WHERE id=?").get(pubId);
+    check("unpublishPost DB row status=draft", row && row.status === "draft");
+    check("unpublishPost preserves publishedAt (legacy parity)", row && !!row.publishedAt);
+  }
+  {
+    const r = await call(handlers.publishPost, makeReq({ params: { id: "0" } }));
+    check("publishPost invalid id -> 400", r.statusCode === 400);
+  }
+  {
+    const r = await call(handlers.publishPost, makeReq({ params: { id: "999999" } }));
+    check("publishPost nonexistent -> 404", r.statusCode === 404);
+  }
+  {
+    const r = await call(handlers.unpublishPost, makeReq({ params: { id: "999999" } }));
+    check("unpublishPost nonexistent -> 404", r.statusCode === 404);
+  }
+
   // ---------- performance: list 1000 posts < 200ms ----------
   // seed 1000 testpost rows, then time a single listPosts call
   {

--- a/server/src/apps/admin/cms/postHandlers.js
+++ b/server/src/apps/admin/cms/postHandlers.js
@@ -218,8 +218,36 @@ function deletePost(req, res) {
   return res.status(200).json({ code: 200, message: "success", data: { deleted: true } });
 }
 
+function publishPost(req, res) {
+  const db = openDb();
+  const id = toInt(req.params.id, 0);
+  if (!id) return res.status(400).json({ code: 400, message: "Invalid id" });
+
+  const updatedAt = nowIso();
+  const publishedAt = nowIso();
+  const info = db
+    .prepare(`UPDATE posts SET status='published', publishedAt=@publishedAt, updatedAt=@updatedAt WHERE id=@id`)
+    .run({ id, publishedAt, updatedAt });
+  if (info.changes === 0) return res.status(404).json({ code: 404, message: "Post not found" });
+  return res.status(200).json({ code: 200, message: "success", data: { id, status: "published", publishedAt, updatedAt } });
+}
+
+function unpublishPost(req, res) {
+  const db = openDb();
+  const id = toInt(req.params.id, 0);
+  if (!id) return res.status(400).json({ code: 400, message: "Invalid id" });
+
+  const updatedAt = nowIso();
+  const info = db
+    .prepare(`UPDATE posts SET status='draft', updatedAt=@updatedAt WHERE id=@id`)
+    .run({ id, updatedAt });
+  if (info.changes === 0) return res.status(404).json({ code: 404, message: "Post not found" });
+  return res.status(200).json({ code: 200, message: "success", data: { id, status: "draft", updatedAt } });
+}
+
 // TODO(T2.8): contentHtml 仍然 lazy-render；前端编辑页若需要可加 ?withHtml=1 参数。
 // TODO(T2.8): 暂未实现批量删除/发布；如需 bulk ops 后续追加 POST /bulk 路由。
+// TODO(T2.9): unpublishPost 故意不清 publishedAt（与 legacy 等价），保留首次发布时间用于审计/排序。
 
 module.exports = {
   listPosts,
@@ -227,4 +255,6 @@ module.exports = {
   createPost,
   updatePost,
   deletePost,
+  publishPost,
+  unpublishPost,
 };

--- a/server/src/apps/admin/cms/postsRouter.js
+++ b/server/src/apps/admin/cms/postsRouter.js
@@ -10,5 +10,7 @@ router.get("/:id", jwtAuth, requirePermission("post:list"), handlers.getPost);
 router.post("/", jwtAuth, requirePermission("post:create"), handlers.createPost);
 router.put("/:id", jwtAuth, requirePermission("post:update"), handlers.updatePost);
 router.delete("/:id", jwtAuth, requirePermission("post:delete"), handlers.deletePost);
+router.post("/:id/publish", jwtAuth, requirePermission("post:publish"), handlers.publishPost);
+router.post("/:id/unpublish", jwtAuth, requirePermission("post:publish"), handlers.unpublishPost);
 
 module.exports = router;


### PR DESCRIPTION
## 变更摘要

为 v2 CMS 增加文章发布 / 下架接口，闭合 T2.9（issue #39）。两条新路由挂在 `/api/v2/admin/cms/posts/:id/{publish,unpublish}`，由 `post:publish` 权限统一守门，含义与 legacy frontApp.js:632-649 完全等价，但响应改为 v2 envelope。

## 新增 / 修改文件

- 修改 [server/src/apps/admin/cms/postHandlers.js](server/src/apps/admin/cms/postHandlers.js) — 新增 `publishPost` / `unpublishPost`，挂到 module.exports
- 修改 [server/src/apps/admin/cms/postsRouter.js](server/src/apps/admin/cms/postsRouter.js) — 新增 2 条路由
- 修改 [server/scripts/check-cms-posts-api.js](server/scripts/check-cms-posts-api.js) — 新增 12 项 publish/unpublish 断言

## 路由表

| Method | Path | Permission | 说明 |
|--------|------|------------|------|
| POST | /api/v2/admin/cms/posts/:id/publish | post:publish | status='published', publishedAt=now, updatedAt=now |
| POST | /api/v2/admin/cms/posts/:id/unpublish | post:publish | status='draft', updatedAt=now（**publishedAt 故意不清**） |

## 新增权限码

无（沿用 T2.8 的 `post:publish`，已在 rbacSeed 中存在）。

## 验收点对照

- [x] POST /:id/publish 把 status 改为 published，并自动写入 publishedAt
- [x] POST /:id/unpublish 把 status 改回 draft，updatedAt 同步更新
- [x] unpublish 不清理 publishedAt（与 legacy 等价，保留首次发布时间用于排序/审计）
- [x] 不存在的 id → 404 `Post not found`
- [x] 非法 id（0 / 非数字）→ 400 `Invalid id`
- [x] T2.7 audit logger 自动捕获两条 POST 请求（无须手动埋点）
- [x] verifier 全部 41 项 PASS（其中 publish/unpublish 12 项；含 DB 行级断言）

## 边界情况 / TODO

- `// TODO(T2.9): unpublishPost 故意不清 publishedAt（与 legacy 等价）` —— 已在源文件落注。如未来产品需求要求"下架后清空发布时间"，单点修改本函数即可。
- 暂不实现批量发布/下架 (`POST /bulk/publish`)；如有需要在 T2.x 追加。

## 冒烟（已跑）

```bash
cd server && node scripts/check-cms-posts-api.js
# → PASS: CMS posts API verified.（41 项）
```

Closes #39