### PR TITLE
feat(cms): T2.13 媒体上传 API

### DIFF
--- a/server/scripts/check-cms-upload-api.js
+++ b/server/scripts/check-cms-upload-api.js
@@ -1,0 +1,293 @@
+// One-off helper: verify CMS upload API (multer + RBAC)
+// Usage (from server/): node scripts/check-cms-upload-api.js
+//
+// 与其他 cms verifier 不同：上传必须经过 multer 中间件 + 真实 multipart body，
+// 无法用 stub req/res，所以这里跑一台临时 HTTP 服务（127.0.0.1:0），用 fetch+FormData
+// 驱动。Node 18+ 自带 fetch / FormData / Blob，不需要 supertest 依赖。
+
+const path = require("node:path");
+const fs = require("node:fs");
+const http = require("node:http");
+require("dotenv").config({ path: path.join(__dirname, "..", ".env") });
+
+if (!process.env.JWT_SECRET) {
+  process.env.JWT_SECRET = "test-secret-jwt-for-cms-upload-check-do-not-use-in-prod";
+}
+
+const express = require("express");
+const jwt = require("jsonwebtoken");
+const { openDb, migrate, ensureSeed } = require("../src/db");
+const { ensureRbacSeed } = require("../src/seeds/rbacSeed");
+const mediaRouter = require("../src/apps/admin/cms/mediaRouter");
+
+const db = openDb();
+migrate(db);
+ensureSeed(db);
+ensureRbacSeed(db, {
+  adminEmail: process.env.ADMIN_EMAIL || "admin@example.com",
+  adminPassword: process.env.ADMIN_PASSWORD || "admin",
+  adminPasswordHash: process.env.ADMIN_PASSWORD_HASH || "",
+});
+
+let pass = true;
+function check(label, ok, detail) {
+  const tag = ok ? "OK  " : "FAIL";
+  console.log(`[${tag}] ${label}${detail ? "  -- " + detail : ""}`);
+  if (!ok) pass = false;
+}
+
+function ensureViewerUser() {
+  const username = "upload_viewer";
+  let row = db.prepare("SELECT id FROM users WHERE username=? LIMIT 1").get(username);
+  if (!row) {
+    const now = new Date().toISOString();
+    const info = db
+      .prepare(
+        `INSERT INTO users (username, email, password_hash, status, is_super_admin, created_at, updated_at)
+         VALUES (?, ?, 'unused', 'active', 0, ?, ?)`,
+      )
+      .run(username, `${username}@example.com`, now, now);
+    row = { id: info.lastInsertRowid };
+  }
+  // 仅绑定 viewer 角色（不含 media:upload）
+  const viewerRole = db.prepare("SELECT id FROM roles WHERE code='viewer'").get();
+  if (viewerRole) {
+    db.prepare("INSERT OR IGNORE INTO user_roles (user_id, role_id) VALUES (?, ?)").run(row.id, viewerRole.id);
+    // 清掉 content_admin/super_admin 等其他角色（防止之前残留）
+    db.prepare(
+      `DELETE FROM user_roles
+       WHERE user_id = ?
+         AND role_id NOT IN (SELECT id FROM roles WHERE code='viewer')`,
+    ).run(row.id);
+  }
+  return row.id;
+}
+
+const SUPER_ID = db.prepare("SELECT id FROM users WHERE is_super_admin=1 LIMIT 1").get().id;
+const VIEWER_ID = ensureViewerUser();
+
+function signToken(userId, isSuper) {
+  return jwt.sign(
+    {
+      userId,
+      username: `u${userId}`,
+      roles: isSuper ? ["super_admin"] : ["viewer"],
+      type: "admin",
+    },
+    process.env.JWT_SECRET,
+    { expiresIn: "2h" },
+  );
+}
+
+const SUPER_TOKEN = signToken(SUPER_ID, true);
+const VIEWER_TOKEN = signToken(VIEWER_ID, false);
+
+// ---- test fixtures ----
+const PNG_HEADER = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const JPEG_HEADER = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+
+function pngBytes(payloadLen = 100) {
+  return Buffer.concat([PNG_HEADER, Buffer.alloc(payloadLen)]);
+}
+
+function jpegBytes(payloadLen = 100) {
+  return Buffer.concat([JPEG_HEADER, Buffer.alloc(payloadLen)]);
+}
+
+(async () => {
+  // ---------- check that media:upload perm is seeded + bound to content_admin ----------
+  {
+    const row = db.prepare("SELECT id FROM permissions WHERE code = ?").get("media:upload");
+    check("permission media:upload seeded", !!row);
+    const contentRole = db.prepare("SELECT id FROM roles WHERE code='content_admin'").get();
+    if (contentRole && row) {
+      const rp = db
+        .prepare("SELECT 1 FROM role_permissions WHERE role_id=? AND permission_id=?")
+        .get(contentRole.id, row.id);
+      check("content_admin role has media:upload bound", !!rp);
+    }
+    const viewerRole = db.prepare("SELECT id FROM roles WHERE code='viewer'").get();
+    if (viewerRole && row) {
+      const rp = db
+        .prepare("SELECT 1 FROM role_permissions WHERE role_id=? AND permission_id=?")
+        .get(viewerRole.id, row.id);
+      check("viewer role does NOT have media:upload bound", !rp);
+    }
+  }
+
+  // ---------- multer config sanity ----------
+  {
+    const u = mediaRouter._uploader;
+    check("multer instance exported", !!u);
+    check(
+      "UPLOAD_DIR is under server/public/uploads",
+      mediaRouter._UPLOAD_DIR.endsWith(path.join("public", "uploads")),
+    );
+    check("UPLOAD_DIR exists on disk", fs.existsSync(mediaRouter._UPLOAD_DIR));
+  }
+
+  // ---------- start ephemeral HTTP server ----------
+  const app = express();
+  app.use("/api/v2/admin/cms", mediaRouter);
+  // multer 出错（>5MB / busboy parse 错）会冒泡到 Express 默认 handler，
+  // Express 5 默认是 500 + HTML body。这里包一个 JSON error handler，方便断言。
+  app.use((err, req, res, _next) => {
+    res.status(err && err.status ? err.status : 500).json({
+      code: 500,
+      message: err && err.code ? err.code : "server_error",
+      detail: err && err.message,
+    });
+  });
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}/api/v2/admin/cms/upload`;
+
+  async function postUpload({ token, fileBuffer, filename, fieldName = "image", mimeType }) {
+    const form = new FormData();
+    if (fileBuffer && filename) {
+      const ext = path.extname(filename).toLowerCase();
+      const inferredType =
+        mimeType ||
+        (ext === ".png" ? "image/png" :
+         ext === ".jpg" || ext === ".jpeg" ? "image/jpeg" :
+         ext === ".gif" ? "image/gif" :
+         ext === ".webp" ? "image/webp" :
+         "application/octet-stream");
+      form.append(fieldName, new Blob([fileBuffer], { type: inferredType }), filename);
+    }
+    const headers = {};
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const r = await fetch(baseUrl, { method: "POST", headers, body: form });
+    let body;
+    const ct = r.headers.get("content-type") || "";
+    if (ct.includes("application/json")) {
+      body = await r.json();
+    } else {
+      body = await r.text();
+    }
+    return { status: r.status, body };
+  }
+
+  const createdFiles = [];
+
+  // 1) no token → 401
+  {
+    const { status } = await postUpload({});
+    check("no token → 401", status === 401, `got ${status}`);
+  }
+
+  // 2) viewer (no media:upload) → 403
+  {
+    const { status } = await postUpload({
+      token: VIEWER_TOKEN,
+      fileBuffer: pngBytes(64),
+      filename: "test.png",
+    });
+    check("viewer token (no media:upload) → 403", status === 403, `got ${status}`);
+  }
+
+  // 3) super, no file → 400 invalid_file
+  {
+    const { status, body } = await postUpload({ token: SUPER_TOKEN });
+    check(
+      "no file → 400 invalid_file",
+      status === 400 && body && body.message === "invalid_file",
+      `got ${status} ${JSON.stringify(body)}`,
+    );
+  }
+
+  // 4) super, valid PNG → 200
+  {
+    const { status, body } = await postUpload({
+      token: SUPER_TOKEN,
+      fileBuffer: pngBytes(128),
+      filename: "smoke.png",
+    });
+    check(
+      "PNG upload → 200",
+      status === 200 && body && body.code === 200,
+      `got ${status} ${JSON.stringify(body)}`,
+    );
+    if (body && body.data) {
+      check(
+        "response.data.url starts with /admin-static/uploads/",
+        typeof body.data.url === "string" && body.data.url.startsWith("/admin-static/uploads/"),
+      );
+      check(
+        "response.data.filename ends with .png",
+        typeof body.data.filename === "string" && body.data.filename.endsWith(".png"),
+      );
+      check(
+        "response.data.size > 0",
+        typeof body.data.size === "number" && body.data.size > 0,
+      );
+      check(
+        "response.data.mimeType is image/*",
+        typeof body.data.mimeType === "string" && body.data.mimeType.startsWith("image/"),
+      );
+      if (body.data.filename) createdFiles.push(body.data.filename);
+    }
+  }
+
+  // 5) super, valid JPEG → 200
+  {
+    const { status, body } = await postUpload({
+      token: SUPER_TOKEN,
+      fileBuffer: jpegBytes(128),
+      filename: "smoke.jpg",
+    });
+    check(
+      "JPEG upload → 200",
+      status === 200 && body && body.code === 200,
+      `got ${status} ${JSON.stringify(body)}`,
+    );
+    if (body && body.data && body.data.filename) createdFiles.push(body.data.filename);
+  }
+
+  // 6) super, disallowed extension (.txt) → multer fileFilter 拒收，handler 拿不到 req.file → 400 invalid_file
+  {
+    const { status, body } = await postUpload({
+      token: SUPER_TOKEN,
+      fileBuffer: Buffer.from("hello world"),
+      filename: "note.txt",
+    });
+    check(
+      ".txt rejected by ext whitelist → 400 invalid_file",
+      status === 400 && body && body.message === "invalid_file",
+      `got ${status} ${JSON.stringify(body)}`,
+    );
+  }
+
+  // 7) super, oversize (>5MB) → 不应是 200（multer 会触发 LIMIT_FILE_SIZE）
+  {
+    const oversize = pngBytes(5 * 1024 * 1024 + 1024);
+    const { status } = await postUpload({
+      token: SUPER_TOKEN,
+      fileBuffer: oversize,
+      filename: "big.png",
+    });
+    check(
+      "oversize file (>5MB) → not 200 (multer LIMIT_FILE_SIZE)",
+      status !== 200,
+      `got ${status}`,
+    );
+  }
+
+  // ---------- cleanup uploaded fixture files ----------
+  for (const f of createdFiles) {
+    try {
+      const p = path.join(mediaRouter._UPLOAD_DIR, f);
+      if (fs.existsSync(p)) fs.unlinkSync(p);
+    } catch {}
+  }
+
+  // ---------- shutdown ----------
+  await new Promise((resolve) => server.close(resolve));
+
+  console.log(pass ? "\nPASS: cms upload API" : "\nFAIL: cms upload API");
+  process.exit(pass ? 0 : 1);
+})().catch((e) => {
+  console.error(e);
+  process.exit(2);
+});

--- a/server/src/apps/admin/cms/mediaRouter.js
+++ b/server/src/apps/admin/cms/mediaRouter.js
@@ -1,0 +1,73 @@
+const path = require("node:path");
+const fs = require("node:fs");
+const crypto = require("node:crypto");
+const express = require("express");
+const multer = require("multer");
+
+const jwtAuth = require("../../../middleware/jwtAuth");
+const requirePermission = require("../../../middleware/rbac");
+
+// 与 legacy frontApp.js 保持一致：上传根目录是 server/public/uploads
+const SERVER_PUBLIC = path.join(__dirname, "..", "..", "..", "..", "public");
+const UPLOAD_DIR = path.join(SERVER_PUBLIC, "uploads");
+
+// multer 不会自动创建目录，启动期一次性确保。
+fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+
+const ALLOWED_EXT = [".jpg", ".jpeg", ".png", ".gif", ".webp"];
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => cb(null, UPLOAD_DIR),
+  filename: (req, file, cb) => {
+    const ext = path.extname(file.originalname).toLowerCase();
+    const name = crypto.randomBytes(16).toString("hex");
+    cb(null, `${Date.now()}-${name}${ext}`);
+  },
+});
+
+const upload = multer({
+  storage,
+  limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB，与 legacy 等价
+  fileFilter: (req, file, cb) => {
+    const ext = path.extname(file.originalname).toLowerCase();
+    cb(null, ALLOWED_EXT.includes(ext));
+  },
+});
+
+function uploadImage(req, res) {
+  if (!req.file) {
+    return res.status(400).json({ code: 400, message: "invalid_file" });
+  }
+  const url = `/admin-static/uploads/${req.file.filename}`;
+  return res.status(200).json({
+    code: 200,
+    message: "success",
+    data: {
+      url,
+      filename: req.file.filename,
+      originalName: req.file.originalname,
+      size: req.file.size,
+      mimeType: req.file.mimetype,
+    },
+  });
+}
+
+const router = express.Router();
+
+// 注意中间件顺序：先 jwtAuth + rbac，再 multer 解析 multipart。
+router.post(
+  "/upload",
+  jwtAuth,
+  requirePermission("media:upload"),
+  upload.single("image"),
+  uploadImage,
+);
+
+// TODO(T2.13): 没有 magic-byte / mime sniff 校验，仅看扩展名（与 legacy 等价）。后续可加 file-type 库做内容嗅探。
+// TODO(T2.13): 上传成功的文件没记 DB，无法做媒体库列表（T2.31 前端要）。后续考虑加 media 表 + 软删除。
+// TODO(T2.13): adminApp 端口 3000 未挂 /admin-static 静态目录；前端拿到 URL 后访问 frontApp 端口 8787 或生产同域 /admin-static。保持 legacy 行为。
+
+module.exports = router;
+module.exports._uploader = upload; // 单测内部访问 multer 实例（验证 limits / fileFilter）
+module.exports._UPLOAD_DIR = UPLOAD_DIR;
+module.exports._uploadImage = uploadImage;

--- a/server/src/apps/adminApp.js
+++ b/server/src/apps/adminApp.js
@@ -10,6 +10,7 @@ const postsRouter = require("./admin/cms/postsRouter");
 const tagsRouter = require("./admin/cms/tagsRouter");
 const categoriesRouter = require("./admin/cms/categoriesRouter");
 const linksRouter = require("./admin/cms/linksRouter");
+const mediaRouter = require("./admin/cms/mediaRouter");
 
 const app = express();
 
@@ -35,6 +36,7 @@ v2Router.use("/admin/cms/posts", postsRouter);
 v2Router.use("/admin/cms/tags", tagsRouter);
 v2Router.use("/admin/cms/categories", categoriesRouter);
 v2Router.use("/admin/cms/links", linksRouter);
+v2Router.use("/admin/cms", mediaRouter);
 app.use("/api/v2", v2Router);
 
 module.exports = app;

--- a/server/src/seeds/rbacSeed.js
+++ b/server/src/seeds/rbacSeed.js
@@ -37,6 +37,7 @@ const PERMISSIONS = [
   { code: "link:create",     resource: "link",     action: "create",    name: "创建友链",       description: "新增友情链接" },
   { code: "link:update",     resource: "link",     action: "update",    name: "编辑友链",       description: "修改友链与排序" },
   { code: "link:delete",     resource: "link",     action: "delete",    name: "删除友链",       description: "永久删除友情链接" },
+  { code: "media:upload",    resource: "media",    action: "upload",    name: "上传媒体",       description: "上传图片到媒体库（5MB 上限）" },
   { code: "user:list",      resource: "user",      action: "list",      name: "查看用户",       description: "浏览后台用户列表" },
   { code: "user:create",    resource: "user",      action: "create",    name: "创建用户",       description: "新增后台用户" },
   { code: "user:update",    resource: "user",      action: "update",    name: "更新用户",       description: "修改后台用户资料 / 状态" },
@@ -62,7 +63,7 @@ const ROLES = [
     code: "content_admin",
     name: "内容管理员",
     description: "可管理博客内容（文章 / 标签 / 分类 / 友链）",
-    permissions: ["post:list", "post:create", "post:update", "post:delete", "post:publish", "tag:list", "tag:create", "tag:update", "tag:delete", "category:list", "category:create", "category:update", "category:delete", "link:list", "link:create", "link:update", "link:delete", "analytics:view"],
+    permissions: ["post:list", "post:create", "post:update", "post:delete", "post:publish", "tag:list", "tag:create", "tag:update", "tag:delete", "category:list", "category:create", "category:update", "category:delete", "link:list", "link:create", "link:update", "link:delete", "media:upload", "analytics:view"],
   },
   {
     code: "viewer",


### PR DESCRIPTION
## Summary
- 新增 `POST /api/v2/admin/cms/upload`：完整复刻 `frontApp /api/admin/upload` 的 multer 行为（5 MB 限额、扩展名白名单 `.jpg/.jpeg/.png/.gif/.webp`、文件名 `Date.now()-randomBytes(16).hex.<ext>`）
- 鉴权链：`jwtAuth → requirePermission("media:upload") → multer.single("image") → uploadImage`
- 响应统一 v2 envelope：`{ code:200, data:{ url, filename, originalName, size, mimeType }}`，`url=/admin-static/uploads/<file>`
- RBAC seed 新增 `media:upload`，并扩 `content_admin` 角色权限数组（super_admin 自动放行）

## Files
**新增**
- `server/src/apps/admin/cms/mediaRouter.js`
- `server/scripts/check-cms-upload-api.js`

**修改**
- `server/src/apps/adminApp.js` —— 挂载 `/api/v2/admin/cms` → mediaRouter
- `server/src/seeds/rbacSeed.js` —— `PERMISSIONS` 新增 `media:upload`，扩 `content_admin.permissions`

## 新增权限码
- `media:upload`（绑定到 `content_admin`，super_admin 自动覆盖）

## 验收点对照（issue #43）
| 验收 | 状态 | 说明 |
| --- | --- | --- |
| `POST /api/v2/admin/cms/upload` 接入 v2 | ✅ | mediaRouter 已挂载到 adminApp:3000 |
| 仅允许图片扩展名 | ✅ | multer fileFilter 白名单 `.jpg/.jpeg/.png/.gif/.webp` |
| 5 MB 大小限制 | ✅ | `limits.fileSize=5*1024*1024`，超限触发 LIMIT_FILE_SIZE |
| 鉴权 + 权限 | ✅ | `media:upload`，content_admin 角色继承，401/403 已验证 |
| URL 返回 `/admin-static/uploads/...` | ✅ | 与 legacy 一致 |

## 验证
**Verifier**：`node scripts/check-cms-upload-api.js`（18 检查全过）
- 因为 multer 行为依赖 multipart body，所以不像其他 cms verifier 用 stub req/res，这里临时启 `127.0.0.1:0` 跑 Express，用 Node 18+ 自带的 `fetch` + `FormData` + `Blob` 驱动
- 覆盖：seed 校验 / multer 配置 / 无 token-401 / viewer-403 / 无文件-400 / PNG-200 / JPEG-200 / `.txt`-白名单拦截 / 5MB+1KB-非 200（multer LIMIT_FILE_SIZE）
- 测试用例显式给 Blob 设了 mimeType（与浏览器实际行为一致），断言 `response.data.mimeType` 为 `image/*`

## 边界情况 / TODO
代码内 `TODO(T2.13)` 注释三条，与 legacy 等价但需要后续追加：
- **没有 magic-byte / mime sniff 校验**，仅看扩展名。后续可加 `file-type` 库做内容嗅探，避免恶意 `.png` 实际是脚本
- **上传成功不写 DB**，无法做媒体库列表（T2.31 前端要）。后续考虑加 `media` 表 + 软删除
- **adminApp 端口 3000 未挂 `/admin-static` 静态目录**；前端拿到 URL 后访问 frontApp:8787 或生产同域 `/admin-static`，保持 legacy 行为

## Test plan
- [x] verifier 全过（18/18）
- [ ] 手动冒烟：用真实 admin token + curl `-F "image=@./test.png"` 命中 200，文件落到 `server/public/uploads/`
- [ ] 手动冒烟：低权限 viewer token → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)