### PR TITLE
feat(admin): T2.16 PageHeader 通用组件

### DIFF
--- a/admin/scripts/check-page-header.ts
+++ b/admin/scripts/check-page-header.ts
@@ -1,0 +1,47 @@
+// Verifies PageHeader common component structure.
+//
+// Usage (from admin/):
+//   npx tsx scripts/check-page-header.ts
+
+import fs from 'node:fs'
+
+let pass = true
+function check(label: string, ok: boolean, detail?: string) {
+  const tag = ok ? 'OK  ' : 'FAIL'
+  console.log(`[${tag}] ${label}${detail ? '  -- ' + detail : ''}`)
+  if (!ok) pass = false
+}
+
+const source = fs.readFileSync('src/components/common/PageHeader.vue', 'utf-8')
+
+// Props
+check('P1: declares props via defineProps', source.includes('defineProps'))
+check('P2: exposes title prop', /title:\s*string/.test(source))
+check('P3: exposes subtitle prop', /subtitle\?:\s*string/.test(source))
+check(
+  'P4: exposes breadcrumbs prop',
+  /breadcrumbs\?:\s*BreadcrumbItem\[\]/.test(source) ||
+    /breadcrumbs\?:\s*Array<\{/.test(source),
+)
+
+// Slots
+check('S1: provides default slot', /<slot\s*\/?>|<slot\s+[^>]*name="default"/.test(source) || /<slot\s*\/>/.test(source))
+check(
+  'S2: provides extra slot',
+  /<slot[^>]+name="extra"/.test(source),
+)
+
+// Naive UI usage
+check('N1: uses NBreadcrumb', source.includes('NBreadcrumb'))
+check('N2: uses NSpace', source.includes('NSpace'))
+
+// Layout
+check('L1: renders title heading', /<h1[\s\S]*?props\.title/.test(source))
+
+console.log('')
+console.log(
+  pass
+    ? 'PASS: PageHeader component verified.'
+    : 'FAIL: see [FAIL] entries above.',
+)
+process.exit(pass ? 0 : 1)

--- a/admin/src/components/common/PageHeader.vue
+++ b/admin/src/components/common/PageHeader.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import {
+  NSpace,
+  NBreadcrumb,
+  NBreadcrumbItem,
+} from 'naive-ui'
+import { useRouter } from 'vue-router'
+
+interface BreadcrumbItem {
+  label: string
+  to?: string
+}
+
+const props = defineProps<{
+  title: string
+  subtitle?: string
+  breadcrumbs?: BreadcrumbItem[]
+}>()
+
+const router = useRouter()
+
+const hasBreadcrumbs = computed(
+  () => Array.isArray(props.breadcrumbs) && props.breadcrumbs.length > 0,
+)
+
+function handleCrumbClick(to: string | undefined) {
+  if (to) router.push(to)
+}
+</script>
+
+<template>
+  <div class="page-header" style="margin-bottom: 24px">
+    <NSpace vertical :size="12">
+      <NBreadcrumb v-if="hasBreadcrumbs">
+        <NBreadcrumbItem
+          v-for="(crumb, i) in props.breadcrumbs"
+          :key="i"
+          :clickable="!!crumb.to"
+          @click="handleCrumbClick(crumb.to)"
+        >
+          {{ crumb.label }}
+        </NBreadcrumbItem>
+      </NBreadcrumb>
+
+      <div
+        style="
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 16px;
+          flex-wrap: wrap;
+        "
+      >
+        <div
+          style="
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            flex-wrap: wrap;
+          "
+        >
+          <h1
+            style="
+              margin: 0;
+              font-size: 22px;
+              font-weight: 600;
+              line-height: 1.4;
+            "
+          >
+            {{ props.title }}
+          </h1>
+          <slot name="extra" />
+        </div>
+
+        <div
+          v-if="props.subtitle"
+          style="
+            flex-basis: 100%;
+            color: var(--color-fg-muted, #888);
+            font-size: 14px;
+            margin-top: -4px;
+          "
+        >
+          {{ props.subtitle }}
+        </div>
+
+        <div style="display: flex; gap: 8px; align-items: center">
+          <slot />
+        </div>
+      </div>
+    </NSpace>
+  </div>
+</template>
+
+<style scoped>
+.page-header {
+  width: 100%;
+}
+</style>


### PR DESCRIPTION
## Summary
- 新增 `admin/src/components/common/PageHeader.vue` 通用页头组件:NSpace 垂直布局,顶部可选面包屑,标题行采用 flex 双区(左 title + extra 槽 + 可选 subtitle,右 default 槽承载操作按钮)。
- 面包屑 item 支持 `to` 字段,有则点击经 vue-router 跳转。
- 沿用项目既有风格(inline style + scoped CSS),不引入 Tailwind utility class。

## 文件改动
- `admin/src/components/common/PageHeader.vue` — 新增组件
- `admin/scripts/check-page-header.ts` — 新增冒烟脚本(9 条断言覆盖 props/slots/NaiveUI/标题渲染)

## 验证
```bash
cd admin
npx tsx scripts/check-page-header.ts   # PASS,9/9
npx vue-tsc --noEmit                   # 0 错误
```

## TODO / 边界
- 顶栏 AdminLayout 已有自动面包屑(由路由 `route.matched` 派生),本组件的 `breadcrumbs` 属于"页内更显眼/手动覆盖"用法,二者并存不冲突;具体页面可自行选择是否使用。

Closes #46