### PR TITLE
feat(admin): T2.21 useTable composable

### DIFF
--- a/admin/scripts/check-use-table.ts
+++ b/admin/scripts/check-use-table.ts
@@ -1,0 +1,213 @@
+// Verifies useTable composable behavior.
+//
+// Usage (from admin/):
+//   npx tsx scripts/check-use-table.ts
+
+import { effectScope, nextTick } from 'vue'
+import { useTable } from '../src/composables/useTable'
+
+let pass = true
+function check(label: string, ok: boolean, detail?: string) {
+  const tag = ok ? 'OK  ' : 'FAIL'
+  console.log(`[${tag}] ${label}${detail ? '  -- ' + detail : ''}`)
+  if (!ok) pass = false
+}
+
+interface Row {
+  id: number
+  name: string
+}
+
+interface Query {
+  keyword?: string
+  status?: string
+}
+
+function makeFetch(rows: Row[], delay = 0) {
+  const counter = { calls: 0 }
+  const fetcher = async (
+    params: Query & { page: number; pageSize: number },
+  ) => {
+    counter.calls += 1
+    if (delay > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delay))
+    }
+    void params
+    return { list: rows.map((r) => ({ ...r })), total: rows.length }
+  }
+  return { fetcher, counter }
+}
+
+async function flush() {
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+// === T1: immediate fetch on mount ===
+{
+  const scope = effectScope()
+  await scope.run(async () => {
+    const rows: Row[] = [{ id: 1, name: 'a' }]
+    const { fetcher, counter } = makeFetch(rows)
+    const t = useTable<Row, Query>({ fetch: fetcher })
+    await flush()
+    check('T1: immediate=true triggers initial fetch', counter.calls === 1)
+    check('T1: data populated', t.data.value.length === 1 && t.data.value[0].id === 1)
+    check('T1: total set', t.total.value === 1)
+    check('T1: loading false after settle', t.loading.value === false)
+  })
+  scope.stop()
+}
+
+// === T2: immediate=false skips initial fetch ===
+{
+  const scope = effectScope()
+  await scope.run(async () => {
+    const { fetcher, counter } = makeFetch([])
+    const t = useTable<Row, Query>({ fetch: fetcher, immediate: false })
+    await flush()
+    check('T2: immediate=false → no initial fetch', counter.calls === 0)
+    void t
+  })
+  scope.stop()
+}
+
+// === T3: changing query resets page to 1 and refetches ===
+{
+  const scope = effectScope()
+  await scope.run(async () => {
+    const { fetcher, counter } = makeFetch([{ id: 1, name: 'a' }])
+    const t = useTable<Row, Query>({
+      fetch: fetcher,
+      initialQuery: {} as Query,
+    })
+    await flush()
+    const initialCalls = counter.calls
+    t.page.value = 3
+    await flush()
+    check('T3a: changing page triggered fetch', counter.calls === initialCalls + 1)
+    check('T3a: page is 3', t.page.value === 3)
+
+    t.query.keyword = 'hello'
+    await flush()
+    check('T3b: page reset to 1 after query change', t.page.value === 1)
+    // page change to 1 may cascade an extra fetch; assert at least one new call.
+    check('T3b: query change triggered refetch', counter.calls > initialCalls + 1)
+  })
+  scope.stop()
+}
+
+// === T4: changing page only does not touch query ===
+{
+  const scope = effectScope()
+  await scope.run(async () => {
+    const { fetcher } = makeFetch([{ id: 1, name: 'a' }])
+    const t = useTable<Row, Query>({
+      fetch: fetcher,
+      initialQuery: { keyword: 'foo' } as Query,
+    })
+    await flush()
+    t.page.value = 2
+    await flush()
+    check('T4: page change keeps query.keyword', t.query.keyword === 'foo')
+    check('T4: page is 2', t.page.value === 2)
+  })
+  scope.stop()
+}
+
+// === T5: race guard — slow first request, fast second wins ===
+{
+  const scope = effectScope()
+  await scope.run(async () => {
+    const slowRows: Row[] = [{ id: 100, name: 'slow' }]
+    const fastRows: Row[] = [{ id: 200, name: 'fast' }]
+
+    let callIdx = 0
+    const fetcher = async (params: Query & { page: number; pageSize: number }) => {
+      const myCall = ++callIdx
+      if (myCall === 1) {
+        await new Promise((r) => setTimeout(r, 60))
+        void params
+        return { list: slowRows.map((r) => ({ ...r })), total: 1 }
+      } else {
+        await new Promise((r) => setTimeout(r, 5))
+        void params
+        return { list: fastRows.map((r) => ({ ...r })), total: 1 }
+      }
+    }
+
+    const t = useTable<Row, Query>({ fetch: fetcher, immediate: false })
+
+    // Fire request #1 (slow), then #2 (fast). Wait for slow to complete.
+    const p1 = t.refresh()
+    const p2 = t.refresh()
+    await Promise.all([p1, p2])
+    await flush()
+
+    check('T5: race guard — final data is from latest request', t.data.value[0]?.id === 200)
+  })
+  scope.stop()
+}
+
+// === T6: handlePageChange / handlePageSizeChange ===
+{
+  const scope = effectScope()
+  await scope.run(async () => {
+    const { fetcher } = makeFetch([])
+    const t = useTable<Row, Query>({ fetch: fetcher, immediate: false })
+    t.handlePageChange(5)
+    check('T6a: handlePageChange sets page', t.page.value === 5)
+    t.handlePageSizeChange(50)
+    check('T6b: handlePageSizeChange sets pageSize', t.pageSize.value === 50)
+    check('T6b: handlePageSizeChange resets page to 1', t.page.value === 1)
+  })
+  scope.stop()
+}
+
+// === T7: error handling ===
+{
+  const scope = effectScope()
+  await scope.run(async () => {
+    const fetcher = async () => {
+      throw new Error('boom')
+    }
+    const t = useTable<Row, Query>({
+      fetch: fetcher as any,
+      immediate: false,
+    })
+    await t.refresh()
+    check('T7: error captured', t.error.value !== null && t.error.value.message === 'boom')
+    check('T7: loading false after error', t.loading.value === false)
+  })
+  scope.stop()
+}
+
+// === T8: reset() restores query and page ===
+{
+  const scope = effectScope()
+  await scope.run(async () => {
+    const { fetcher } = makeFetch([])
+    const t = useTable<Row, Query>({
+      fetch: fetcher,
+      initialQuery: { keyword: 'init' } as Query,
+    })
+    await flush()
+    t.query.keyword = 'changed'
+    t.page.value = 3
+    await flush()
+    await t.reset()
+    await flush()
+    check('T8: reset restored keyword', t.query.keyword === 'init')
+    check('T8: reset page to 1', t.page.value === 1)
+  })
+  scope.stop()
+}
+
+console.log('')
+console.log(
+  pass
+    ? 'PASS: useTable composable verified.'
+    : 'FAIL: see [FAIL] entries above.',
+)
+process.exit(pass ? 0 : 1)

--- a/admin/src/composables/useTable.ts
+++ b/admin/src/composables/useTable.ts
@@ -1,0 +1,145 @@
+import { ref, reactive, watch, type Ref } from 'vue'
+
+export interface PageQuery {
+  page: number
+  pageSize: number
+}
+
+export interface UseTableFetchResult<TRow> {
+  list: TRow[]
+  total: number
+}
+
+export interface UseTableOptions<TRow, TQuery extends object> {
+  fetch: (
+    params: TQuery & PageQuery,
+  ) => Promise<UseTableFetchResult<TRow>>
+  initialQuery?: TQuery
+  pageSize?: number
+  immediate?: boolean
+}
+
+export interface UseTableReturn<TRow, TQuery extends object> {
+  data: Ref<TRow[]>
+  total: Ref<number>
+  page: Ref<number>
+  pageSize: Ref<number>
+  loading: Ref<boolean>
+  error: Ref<Error | null>
+  query: TQuery
+  refresh(): Promise<void>
+  reset(): Promise<void>
+  handlePageChange(p: number): void
+  handlePageSizeChange(s: number): void
+}
+
+export function useTable<TRow, TQuery extends object = Record<string, unknown>>(
+  opts: UseTableOptions<TRow, TQuery>,
+): UseTableReturn<TRow, TQuery> {
+  const initialPageSize = opts.pageSize ?? 20
+  const immediate = opts.immediate !== false
+  const initialQuery = (opts.initialQuery ?? ({} as TQuery))
+
+  const data = ref([]) as Ref<TRow[]>
+  const total = ref(0)
+  const page = ref(1)
+  const pageSize = ref(initialPageSize)
+  const loading = ref(false)
+  const error = ref<Error | null>(null)
+
+  const query = reactive<Record<string, unknown>>({
+    ...(initialQuery as Record<string, unknown>),
+  }) as TQuery
+
+  let requestId = 0
+  let suppressQueryWatch = false
+
+  async function refresh(): Promise<void> {
+    const myId = ++requestId
+    loading.value = true
+    error.value = null
+    try {
+      const params = {
+        ...(query as object),
+        page: page.value,
+        pageSize: pageSize.value,
+      } as TQuery & PageQuery
+
+      const res = await opts.fetch(params)
+      // Race guard: only the latest request applies its result.
+      if (myId !== requestId) return
+
+      data.value = res.list ?? []
+      total.value = res.total ?? 0
+    } catch (e) {
+      if (myId !== requestId) return
+      error.value = e instanceof Error ? e : new Error(String(e))
+    } finally {
+      if (myId === requestId) {
+        loading.value = false
+      }
+    }
+  }
+
+  async function reset(): Promise<void> {
+    suppressQueryWatch = true
+    Object.keys(query as object).forEach((k) => {
+      delete (query as Record<string, unknown>)[k]
+    })
+    Object.assign(query as object, initialQuery as object)
+    page.value = 1
+    pageSize.value = initialPageSize
+    // Allow watchers to flush, then refresh once.
+    await Promise.resolve()
+    suppressQueryWatch = false
+    await refresh()
+  }
+
+  function handlePageChange(p: number): void {
+    page.value = p
+  }
+
+  function handlePageSizeChange(s: number): void {
+    pageSize.value = s
+    page.value = 1
+  }
+
+  // Pagination changes: refresh.
+  watch([page, pageSize], () => {
+    if (suppressQueryWatch) return
+    void refresh()
+  })
+
+  // Query changes: reset to page 1, then refresh.
+  watch(
+    () => ({ ...(query as object) }),
+    () => {
+      if (suppressQueryWatch) return
+      if (page.value !== 1) {
+        // Setting page to 1 will trigger the pagination watcher above.
+        page.value = 1
+      } else {
+        void refresh()
+      }
+    },
+    { deep: true },
+  )
+
+  if (immediate) {
+    void refresh()
+  }
+
+  return {
+    data,
+    total,
+    page,
+    pageSize,
+    loading,
+    error,
+    query,
+    refresh,
+    reset,
+    handlePageChange,
+    handlePageSizeChange,
+  }
+}


### PR DESCRIPTION
## Summary
- 新增 `admin/src/composables/useTable.ts` 泛型分页表格 hook,封装 data/total/page/loading/error/query 状态与 refresh/reset/handlers。
- 内置 race guard(`requestId` 自增,只采纳最新请求结果)与 query 深 watch 自动回 page=1。
- 暴露的 API 与 NDataTable + NPagination 直接契合,后续 T2.17 DataTable 在其上薄包装即可。

## 文件改动
- `admin/src/composables/useTable.ts` — 新增 hook
- `admin/scripts/check-use-table.ts` — 新增冒烟脚本(8 组共 19 条断言)

## 验证
\`\`\`bash
cd admin
npx tsx scripts/check-use-table.ts   # PASS,19/19
npx vue-tsc --noEmit                 # 0 错误
\`\`\`

## TODO / 边界
- 未提供 sortBy/sortOrder 字段(后端 list 接口目前不一定都支持排序);DataTable 需要时再在调用方扩展 query 即可。

Closes #51