### PR TITLE
feat(admin): T2.17 DataTable 通用组件

### DIFF
--- a/admin/scripts/check-data-table.ts
+++ b/admin/scripts/check-data-table.ts
@@ -1,0 +1,67 @@
+// Verifies DataTable common component structure.
+//
+// Usage (from admin/):
+//   npx tsx scripts/check-data-table.ts
+
+import fs from 'node:fs'
+
+let pass = true
+function check(label: string, ok: boolean, detail?: string) {
+  const tag = ok ? 'OK  ' : 'FAIL'
+  console.log(`[${tag}] ${label}${detail ? '  -- ' + detail : ''}`)
+  if (!ok) pass = false
+}
+
+const source = fs.readFileSync('src/components/common/DataTable.vue', 'utf-8')
+
+// Generic component
+check(
+  'G1: declares generic <script setup lang="ts" generic=...>',
+  /<script\s+setup[^>]+generic=/.test(source),
+)
+
+// Composable wiring
+check('U1: imports useTable composable', source.includes('useTable'))
+
+// Props
+check('P1: declares props via defineProps', source.includes('defineProps'))
+check('P2: declares columns prop', /columns:\s*DataTableColumns/.test(source))
+check('P3: declares fetch prop', /fetch:\s*\(/.test(source))
+check('P4: declares pageSize prop', /pageSize\?:\s*number/.test(source))
+check('P5: declares selectable prop', /selectable\?:\s*boolean/.test(source))
+check('P6: declares rowKey prop', /rowKey\?:/.test(source))
+
+// Naive UI components
+check('N1: uses NDataTable', source.includes('NDataTable'))
+check('N2: uses NPagination', source.includes('NPagination'))
+check('N3: uses NEmpty for empty state', source.includes('NEmpty'))
+check('N4: uses NInput for default search', source.includes('NInput'))
+
+// Slots
+check('S1: provides toolbar slot', /<slot[^>]*name="toolbar"/.test(source))
+check('S2: provides search slot', /<slot[^>]*name="search"/.test(source))
+check('S3: provides empty slot', /<slot[^>]*name="empty"/.test(source))
+
+// Emits
+check('E1: emits update:selectedRowKeys', source.includes('update:selectedRowKeys'))
+
+// Expose
+check('X1: defineExpose with refresh+clearSelection', /defineExpose\([^)]*refresh[^)]*clearSelection|defineExpose\([^)]*clearSelection[^)]*refresh/s.test(source))
+
+// Pagination handlers wired
+check(
+  'PG1: pagination wired to handlePageChange',
+  source.includes('handlePageChange'),
+)
+check(
+  'PG2: pagination wired to handlePageSizeChange',
+  source.includes('handlePageSizeChange'),
+)
+
+console.log('')
+console.log(
+  pass
+    ? 'PASS: DataTable component verified.'
+    : 'FAIL: see [FAIL] entries above.',
+)
+process.exit(pass ? 0 : 1)

--- a/admin/src/components/common/DataTable.vue
+++ b/admin/src/components/common/DataTable.vue
@@ -1,0 +1,160 @@
+<script setup lang="ts" generic="TRow, TQuery extends object = Record<string, unknown>">
+import { computed, ref } from 'vue'
+import {
+  NDataTable,
+  NPagination,
+  NSpace,
+  NInput,
+  NButton,
+  NIcon,
+  NEmpty,
+  type DataTableColumns,
+  type DataTableRowKey,
+} from 'naive-ui'
+import { RefreshOutline } from '@vicons/ionicons5'
+import { useTable } from '../../composables/useTable'
+
+interface Props {
+  columns: DataTableColumns<TRow>
+  fetch: (
+    params: TQuery & { page: number; pageSize: number },
+  ) => Promise<{ list: TRow[]; total: number }>
+  initialQuery?: TQuery
+  pageSize?: number
+  rowKey?: (row: TRow) => DataTableRowKey
+  selectable?: boolean
+  searchPlaceholder?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  initialQuery: undefined,
+  pageSize: 20,
+  rowKey: undefined,
+  selectable: false,
+  searchPlaceholder: '搜索关键字',
+})
+
+const emit = defineEmits<{
+  (e: 'update:selectedRowKeys', keys: DataTableRowKey[]): void
+}>()
+
+const table = useTable<TRow, TQuery>({
+  fetch: props.fetch,
+  initialQuery: props.initialQuery,
+  pageSize: props.pageSize,
+})
+
+const selectedRowKeys = ref<DataTableRowKey[]>([])
+
+function handleSelectionChange(keys: DataTableRowKey[]) {
+  selectedRowKeys.value = keys
+  emit('update:selectedRowKeys', keys)
+}
+
+function clearSelection() {
+  selectedRowKeys.value = []
+  emit('update:selectedRowKeys', [])
+}
+
+defineExpose({
+  refresh: table.refresh,
+  reset: table.reset,
+  clearSelection,
+})
+
+const totalPages = computed(() =>
+  Math.max(1, Math.ceil(table.total.value / table.pageSize.value)),
+)
+
+const showEmpty = computed(
+  () => !table.loading.value && table.data.value.length === 0,
+)
+
+const queryAsRecord = table.query as Record<string, unknown>
+</script>
+
+<template>
+  <div class="data-table-wrap">
+    <div
+      class="data-table-toolbar"
+      style="
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin-bottom: 16px;
+        flex-wrap: wrap;
+      "
+    >
+      <div style="flex: 1; min-width: 240px; max-width: 480px">
+        <slot name="search" :query="table.query" :refresh="table.refresh">
+          <NInput
+            v-model:value="(queryAsRecord.keyword as string)"
+            :placeholder="props.searchPlaceholder"
+            clearable
+          />
+        </slot>
+      </div>
+      <NSpace>
+        <NButton
+          quaternary
+          circle
+          :loading="table.loading.value"
+          @click="table.refresh()"
+        >
+          <NIcon><RefreshOutline /></NIcon>
+        </NButton>
+        <slot
+          name="toolbar"
+          :selected-keys="selectedRowKeys"
+          :clear-selection="clearSelection"
+          :refresh="table.refresh"
+        />
+      </NSpace>
+    </div>
+
+    <NDataTable
+      :columns="props.columns"
+      :data="table.data.value"
+      :loading="table.loading.value"
+      :row-key="props.rowKey"
+      :checked-row-keys="selectedRowKeys"
+      :pagination="false"
+      :bordered="false"
+      remote
+      @update:checked-row-keys="handleSelectionChange"
+    >
+      <template v-if="showEmpty" #empty>
+        <slot name="empty">
+          <NEmpty description="暂无数据" />
+        </slot>
+      </template>
+    </NDataTable>
+
+    <div
+      class="data-table-pagination"
+      style="
+        margin-top: 16px;
+        display: flex;
+        justify-content: flex-end;
+      "
+    >
+      <NPagination
+        :page="table.page.value"
+        :page-size="table.pageSize.value"
+        :item-count="table.total.value"
+        :page-count="totalPages"
+        :page-sizes="[10, 20, 50, 100]"
+        show-size-picker
+        @update:page="table.handlePageChange"
+        @update:page-size="table.handlePageSizeChange"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.data-table-wrap {
+  width: 100%;
+}
+</style>


### PR DESCRIPTION
## Summary
- 新增 `admin/src/components/common/DataTable.vue` 通用数据表组件,以 `useTable` (T2.21) 为底,组合 NDataTable + NPagination 加默认搜索/刷新工具栏。
- 泛型 `<TRow, TQuery>`,columns 直接透传;父组件可通过 `ref` 调 `refresh()` / `reset()` / `clearSelection()`。
- 三个槽位:`search`(替换默认搜索框)、`toolbar`(右侧操作区,暴露 selectedKeys 作用域)、`empty`。

## 文件改动
- `admin/src/components/common/DataTable.vue` — 新增组件
- `admin/scripts/check-data-table.ts` — 新增冒烟脚本(19 条断言)

## 验证
\`\`\`bash
cd admin
npx tsx scripts/check-data-table.ts   # PASS,19/19
npx vue-tsc --noEmit                  # 0 错误
\`\`\`

## TODO / 边界
- 批量操作浮动条(已选 N 项 → 操作按钮)未在内置 toolbar 渲染,而是把 selectedKeys 通过作用域 slot 暴露,业务页自行实现样式,避免一刀切。
- 默认搜索框只支持单字段 keyword;复杂筛选(多个字段、状态枚举等)请用 `search` slot 自渲染,通过 scope.query 双向写入。

Closes #47