### PR TITLE
feat(admin): T2.18 FormDrawer 通用组件

### DIFF
--- a/admin/scripts/check-form-drawer.ts
+++ b/admin/scripts/check-form-drawer.ts
@@ -1,0 +1,55 @@
+// Verifies FormDrawer common component structure.
+//
+// Usage (from admin/):
+//   npx tsx scripts/check-form-drawer.ts
+
+import fs from 'node:fs'
+
+let pass = true
+function check(label: string, ok: boolean, detail?: string) {
+  const tag = ok ? 'OK  ' : 'FAIL'
+  console.log(`[${tag}] ${label}${detail ? '  -- ' + detail : ''}`)
+  if (!ok) pass = false
+}
+
+const source = fs.readFileSync('src/components/common/FormDrawer.vue', 'utf-8')
+
+// Naive UI elements
+check('N1: uses NDrawer', source.includes('NDrawer'))
+check('N2: uses NDrawerContent', source.includes('NDrawerContent'))
+check('N3: default footer renders NSpace + NButton', source.includes('NSpace') && /NButton/.test(source))
+
+// Props
+check('P1: declares show prop', /show:\s*boolean/.test(source))
+check('P2: declares title prop', /title:\s*string/.test(source))
+check('P3: declares width prop', /width\?:/.test(source))
+check('P4: declares loading prop', /loading\?:\s*boolean/.test(source))
+check('P5: declares submitText/cancelText', source.includes('submitText') && source.includes('cancelText'))
+check('P6: declares closeOnConfirm prop', /closeOnConfirm\?:\s*boolean/.test(source))
+
+// Emits
+check("E1: emits 'update:show'", source.includes("'update:show'"))
+check("E2: emits 'submit'", source.includes("'submit'"))
+check("E3: emits 'cancel'", source.includes("'cancel'"))
+
+// Slots
+check('S1: provides default slot', /<slot\s*\/>/.test(source))
+check('S2: provides footer slot', /<slot[^>]*name="footer"/.test(source))
+
+// v-model:show wiring
+check(
+  'V1: forwards :show + @update:show (v-model:show contract)',
+  /:show="props\.show"/.test(source) && /update:show/.test(source),
+)
+
+// Default button labels honored
+check('L1: default submit text reads from prop', /props\.submitText/.test(source))
+check('L2: default cancel text reads from prop', /props\.cancelText/.test(source))
+
+console.log('')
+console.log(
+  pass
+    ? 'PASS: FormDrawer component verified.'
+    : 'FAIL: see [FAIL] entries above.',
+)
+process.exit(pass ? 0 : 1)

--- a/admin/src/components/common/FormDrawer.vue
+++ b/admin/src/components/common/FormDrawer.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+/**
+ * 通用表单抽屉。
+ *
+ * 用法:
+ * - 创建/编辑共用同一抽屉,父组件按 mode 控制 title 与初始值。
+ * - <slot /> 放 NForm 主体。
+ * - <slot name="footer" /> 自定义底部按钮(默认提供取消/确定)。
+ * - 父组件监听 @submit 触发实际接口;成功后再 update:show=false。
+ *
+ * @example
+ *   <FormDrawer v-model:show="open" title="新建用户" :loading="saving" @submit="handleSave">
+ *     <NForm ...>...</NForm>
+ *   </FormDrawer>
+ */
+import {
+  NDrawer,
+  NDrawerContent,
+  NSpace,
+  NButton,
+} from 'naive-ui'
+
+interface Props {
+  show: boolean
+  title: string
+  width?: number | string
+  loading?: boolean
+  submitText?: string
+  cancelText?: string
+  closeOnConfirm?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  width: 480,
+  loading: false,
+  submitText: '确定',
+  cancelText: '取消',
+  closeOnConfirm: false,
+})
+
+const emit = defineEmits<{
+  (e: 'update:show', value: boolean): void
+  (e: 'submit'): void
+  (e: 'cancel'): void
+}>()
+
+function handleCancel() {
+  emit('cancel')
+  emit('update:show', false)
+}
+
+function handleSubmit() {
+  emit('submit')
+  if (props.closeOnConfirm) {
+    emit('update:show', false)
+  }
+}
+
+function handleUpdateShow(value: boolean) {
+  emit('update:show', value)
+}
+</script>
+
+<template>
+  <NDrawer
+    :show="props.show"
+    :width="props.width"
+    placement="right"
+    @update:show="handleUpdateShow"
+  >
+    <NDrawerContent :title="props.title" closable>
+      <div class="form-drawer-body">
+        <slot />
+      </div>
+
+      <template #footer>
+        <slot name="footer" :submit="handleSubmit" :cancel="handleCancel" :loading="props.loading">
+          <NSpace>
+            <NButton @click="handleCancel">{{ props.cancelText }}</NButton>
+            <NButton
+              type="primary"
+              :loading="props.loading"
+              :disabled="props.loading"
+              @click="handleSubmit"
+            >
+              {{ props.submitText }}
+            </NButton>
+          </NSpace>
+        </slot>
+      </template>
+    </NDrawerContent>
+  </NDrawer>
+</template>
+
+<style scoped>
+.form-drawer-body {
+  padding-bottom: 8px;
+}
+</style>


### PR DESCRIPTION
## Summary
- 新增 `admin/src/components/common/FormDrawer.vue`:右侧抽屉表单容器,基于 NDrawer + NDrawerContent。
- v-model:show 双向绑定;`submit` / `cancel` 双 emit;父组件成功后自行收起。
- footer 槽可覆盖默认按钮(暴露 submit/cancel/loading 作用域)。

## 文件改动
- `admin/src/components/common/FormDrawer.vue` — 新增组件
- `admin/scripts/check-form-drawer.ts` — 新增冒烟脚本(17 条断言)

## 验证
\`\`\`bash
cd admin
npx tsx scripts/check-form-drawer.ts   # PASS,17/17
npx vue-tsc --noEmit                   # 0 错误
\`\`\`

## TODO / 边界
- `closeOnConfirm` 默认 false,即父组件需在 submit 完成后显式 `update:show = false`。这是为了让父组件做完接口校验/错误提示再决定是否关。

Closes #48