### PR TITLE
feat(admin): T2.20 ImageUploader 组件

### DIFF
--- a/admin/scripts/check-image-uploader.ts
+++ b/admin/scripts/check-image-uploader.ts
@@ -1,0 +1,131 @@
+// Verifies ImageUploader component + apiUpload wrapper.
+//
+// Vue SFC needs DOM to mount, so SFC checks are text-based. apiUpload is
+// runtime-testable by injecting a stubbed AxiosInstance.
+//
+// Usage (from admin/):
+//   npx tsx scripts/check-image-uploader.ts
+
+import fs from 'node:fs'
+import type { AxiosInstance, AxiosResponse } from 'axios'
+import { apiUpload } from '../src/api/cms'
+
+let pass = true
+function check(label: string, ok: boolean, detail?: string) {
+  const tag = ok ? 'OK  ' : 'FAIL'
+  console.log(`[${tag}] ${label}${detail ? '  -- ' + detail : ''}`)
+  if (!ok) pass = false
+}
+
+interface PostCall {
+  url: string
+  data: unknown
+  config: { headers?: Record<string, string>; onUploadProgress?: (e: { loaded: number; total: number }) => void }
+}
+
+function makeFakeAxios(response: { code: number; message: string; data: unknown }) {
+  const calls: PostCall[] = []
+  const fake = {
+    async post(url: string, data: unknown, config: PostCall['config'] = {}) {
+      calls.push({ url, data, config })
+      // Simulate progress events.
+      config.onUploadProgress?.({ loaded: 50, total: 100 })
+      config.onUploadProgress?.({ loaded: 100, total: 100 })
+      return {
+        data: response,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      } as AxiosResponse
+    },
+  } as unknown as AxiosInstance
+  return { fake, calls }
+}
+
+// === A1: apiUpload posts a multipart form to the right URL ===
+{
+  const { fake, calls } = makeFakeAxios({ code: 0, message: 'ok', data: { url: '/uploads/a.png' } })
+  const file = new File(['hello'], 'a.png', { type: 'image/png' })
+  const result = await apiUpload(file, {}, fake)
+
+  check('A1: returns backend data block', result.url === '/uploads/a.png')
+  check('A1: posts to /api/v2/admin/cms/upload', calls.length === 1 && calls[0].url === '/api/v2/admin/cms/upload')
+  check(
+    'A1: sets multipart/form-data header',
+    calls[0].config?.headers?.['Content-Type'] === 'multipart/form-data',
+  )
+  check(
+    'A1: body is FormData with field "file"',
+    calls[0].data instanceof FormData && (calls[0].data as FormData).has('file'),
+  )
+}
+
+// === A2: progress callback is invoked with integer percent ===
+{
+  const { fake } = makeFakeAxios({ code: 0, message: 'ok', data: { url: '/uploads/p.png' } })
+  const file = new File(['x'], 'p.png', { type: 'image/png' })
+  const seen: number[] = []
+  await apiUpload(file, { onProgress: (p) => seen.push(p) }, fake)
+  check('A2: progress callback called twice', seen.length === 2)
+  check('A2: progress percent is integer 50 then 100', seen[0] === 50 && seen[1] === 100)
+}
+
+// === A3: progress callback skipped when total is 0 ===
+{
+  const fake = {
+    async post(url: string, data: unknown, config: PostCall['config'] = {}) {
+      config.onUploadProgress?.({ loaded: 50, total: 0 })
+      return {
+        data: { code: 0, message: 'ok', data: { url: '/uploads/z.png' } },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+        request: undefined,
+      } as AxiosResponse
+      void url
+      void data
+    },
+  } as unknown as AxiosInstance
+  const file = new File(['x'], 'z.png', { type: 'image/png' })
+  const seen: number[] = []
+  await apiUpload(file, { onProgress: (p) => seen.push(p) }, fake)
+  check('A3: progress skipped when total is 0 (avoids NaN)', seen.length === 0)
+}
+
+// === SFC text assertions ===
+{
+  const sfc = fs.readFileSync('src/components/common/ImageUploader.vue', 'utf-8')
+
+  // Naive UI usage
+  check('S1: uses NUpload', sfc.includes('NUpload'))
+  check('S2: uses NUploadDragger for drag area', sfc.includes('NUploadDragger'))
+  check('S3: list-type set to image-card', /list-type="image-card"/.test(sfc))
+  check('S4: registers custom-request handler', sfc.includes('custom-request'))
+  check('S5: registers before-upload handler', sfc.includes('before-upload'))
+  check('S6: imports apiUpload', sfc.includes("from '../../api/cms'") && sfc.includes('apiUpload'))
+
+  // Props
+  check('P1: declares modelValue prop (string | string[])', /modelValue:\s*string\s*\|\s*string\[\]/.test(sfc))
+  check('P2: declares multiple prop', /multiple\?:\s*boolean/.test(sfc))
+  check('P3: declares max prop', /max\?:\s*number/.test(sfc))
+  check('P4: declares accept prop', /accept\?:\s*string/.test(sfc))
+  check('P5: declares maxSize prop', /maxSize\?:\s*number/.test(sfc))
+
+  // Emits
+  check('E1: emits update:modelValue', sfc.includes("'update:modelValue'"))
+
+  // Behavior
+  check('B1: validates MIME type via accept rule', sfc.includes('accept') && sfc.includes('image/'))
+  check('B2: validates file size against maxSize', sfc.includes('maxSize'))
+  check('B3: progress wired through onUploadProgress chain', sfc.includes('onProgress') && sfc.includes('opts.onProgress'))
+}
+
+console.log('')
+console.log(
+  pass
+    ? 'PASS: ImageUploader + apiUpload verified.'
+    : 'FAIL: see [FAIL] entries above.',
+)
+process.exit(pass ? 0 : 1)

--- a/admin/src/api/cms.ts
+++ b/admin/src/api/cms.ts
@@ -1,0 +1,50 @@
+// Typed wrappers around v2 CMS endpoints (uploads, posts, tags, etc.).
+// Mirrors the same pattern as ./auth.ts:
+//   apiXxx(...args, client = request) → returns res.data.data
+//
+// Lets test code inject a mocked AxiosInstance via createRequest({...}).
+
+import { request, type ApiResponse } from './request'
+import type { AxiosInstance, AxiosProgressEvent } from 'axios'
+
+export interface UploadResultData {
+  url: string
+  filename?: string
+  size?: number
+  mimeType?: string
+}
+
+export interface UploadOptions {
+  onProgress?: (percent: number) => void
+  signal?: AbortSignal
+}
+
+/**
+ * Upload a single image to /api/v2/admin/cms/upload.
+ *
+ * Returns the backend `data` block — typically `{ url }`.
+ * Progress callback receives an integer 0-100.
+ */
+export async function apiUpload(
+  file: File,
+  options: UploadOptions = {},
+  client: AxiosInstance = request,
+): Promise<UploadResultData> {
+  const form = new FormData()
+  form.append('file', file)
+
+  const res = await client.post<ApiResponse<UploadResultData>>(
+    '/api/v2/admin/cms/upload',
+    form,
+    {
+      headers: { 'Content-Type': 'multipart/form-data' },
+      signal: options.signal,
+      onUploadProgress: (evt: AxiosProgressEvent) => {
+        if (!options.onProgress || !evt.total) return
+        const percent = Math.round((evt.loaded * 100) / evt.total)
+        options.onProgress(percent)
+      },
+    },
+  )
+  return res.data.data
+}

--- a/admin/src/components/common/ImageUploader.vue
+++ b/admin/src/components/common/ImageUploader.vue
@@ -1,0 +1,197 @@
+<script setup lang="ts">
+/**
+ * 通用图片上传组件。
+ *
+ * - v-model:modelValue 单图为 string,多图为 string[]
+ * - 默认 `image-card` 网格布局,支持拖拽
+ * - before-upload 校验 MIME / 体积,失败提示
+ * - custom-request 调 apiUpload(走统一 axios 拦截器,401 自动续期)
+ *
+ * @example 单图
+ *   <ImageUploader v-model="cover" />
+ *
+ * @example 多图
+ *   <ImageUploader v-model="gallery" multiple :max="6" />
+ */
+import { computed, ref, watch } from 'vue'
+import {
+  NUpload,
+  NUploadDragger,
+  NIcon,
+  NText,
+  useMessage,
+  type UploadCustomRequestOptions,
+  type UploadFileInfo,
+} from 'naive-ui'
+import { CloudUploadOutline } from '@vicons/ionicons5'
+import { apiUpload } from '../../api/cms'
+
+interface Props {
+  modelValue: string | string[]
+  multiple?: boolean
+  max?: number
+  accept?: string
+  maxSize?: number  // MB
+  drag?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  multiple: false,
+  max: 9,
+  accept: 'image/*',
+  maxSize: 10,
+  drag: true,
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string | string[]): void
+}>()
+
+const message = useMessage()
+
+// Normalize modelValue → string[] internally; emit shape that matches inbound.
+const fileList = ref<UploadFileInfo[]>([])
+
+function urlsFromModel(): string[] {
+  if (Array.isArray(props.modelValue)) return [...props.modelValue]
+  return props.modelValue ? [props.modelValue] : []
+}
+
+function syncFromModel() {
+  fileList.value = urlsFromModel().map((url, i) => ({
+    id: `seed-${i}-${url}`,
+    name: url.split('/').pop() ?? `image-${i}`,
+    status: 'finished',
+    url,
+  } as UploadFileInfo))
+}
+
+syncFromModel()
+
+watch(
+  () => props.modelValue,
+  () => {
+    // External resets: reflect into the visible list.
+    const incoming = urlsFromModel()
+    const current = fileList.value
+      .filter((f) => f.status === 'finished' && f.url)
+      .map((f) => f.url as string)
+    const same =
+      incoming.length === current.length &&
+      incoming.every((u, i) => u === current[i])
+    if (!same) syncFromModel()
+  },
+)
+
+const showUploadButton = computed(() => {
+  if (!props.multiple) {
+    return urlsFromModel().length === 0
+  }
+  return urlsFromModel().length < props.max
+})
+
+function emitUrls(urls: string[]) {
+  if (props.multiple) {
+    emit('update:modelValue', urls)
+  } else {
+    emit('update:modelValue', urls[0] ?? '')
+  }
+}
+
+function handleBeforeUpload(data: { file: UploadFileInfo }) {
+  const raw = data.file.file
+  if (!raw) return false
+
+  if (props.accept && props.accept !== '*') {
+    const acceptList = props.accept.split(',').map((s) => s.trim())
+    const matched = acceptList.some((rule) => {
+      if (rule === 'image/*') return raw.type.startsWith('image/')
+      if (rule.endsWith('/*')) return raw.type.startsWith(rule.slice(0, -1))
+      return raw.type === rule
+    })
+    if (!matched) {
+      message.error(`不支持的文件类型: ${raw.type || '未知'}`)
+      return false
+    }
+  }
+
+  const sizeMB = raw.size / 1024 / 1024
+  if (sizeMB > props.maxSize) {
+    message.error(`文件超过 ${props.maxSize}MB 限制`)
+    return false
+  }
+  return true
+}
+
+async function handleCustomRequest(opts: UploadCustomRequestOptions) {
+  const raw = opts.file.file
+  if (!raw) {
+    opts.onError()
+    return
+  }
+
+  try {
+    const result = await apiUpload(raw, {
+      onProgress: (percent) => opts.onProgress({ percent }),
+    })
+    // Merge backend url into the file list and emit.
+    opts.file.url = result.url
+    opts.onFinish()
+
+    const finished = fileList.value
+      .filter((f) => f.status === 'finished' && f.url)
+      .map((f) => f.url as string)
+    if (!finished.includes(result.url)) finished.push(result.url)
+    if (!props.multiple) {
+      emitUrls([result.url])
+    } else {
+      emitUrls(finished)
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : '上传失败'
+    message.error(msg)
+    opts.onError()
+  }
+}
+
+function handleRemove(data: { file: UploadFileInfo }) {
+  const remaining = fileList.value
+    .filter((f) => f.id !== data.file.id && f.status === 'finished' && f.url)
+    .map((f) => f.url as string)
+  emitUrls(remaining)
+  return true
+}
+</script>
+
+<template>
+  <div class="image-uploader">
+    <NUpload
+      v-model:file-list="fileList"
+      :multiple="props.multiple"
+      :max="props.max"
+      :accept="props.accept"
+      list-type="image-card"
+      :show-file-list="true"
+      :default-upload="true"
+      :custom-request="handleCustomRequest"
+      @before-upload="handleBeforeUpload"
+      @remove="handleRemove"
+    >
+      <NUploadDragger v-if="props.drag && showUploadButton">
+        <div style="margin-bottom: 8px">
+          <NIcon size="32" :depth="3"><CloudUploadOutline /></NIcon>
+        </div>
+        <NText>点击或拖拽图片到此区域上传</NText>
+        <div style="font-size: 12px; color: #999; margin-top: 4px">
+          支持 {{ props.accept }},单文件不超过 {{ props.maxSize }}MB
+        </div>
+      </NUploadDragger>
+    </NUpload>
+  </div>
+</template>
+
+<style scoped>
+.image-uploader {
+  width: 100%;
+}
+</style>


### PR DESCRIPTION
## Summary

- 新增 `admin/src/components/common/ImageUploader.vue`:通用图片上传组件
- v-model:modelValue 兼容单图 (`string`) / 多图 (`string[]`)
- 基于 NUpload + NUploadDragger,拖拽 / 点击上传,image-card 网格预览
- 上传走统一 `apiUpload`(`/api/v2/admin/cms/upload`),401 自动续期由 axios 拦截器处理

## 文件改动

- `admin/src/api/cms.ts` — 新增 `apiUpload(file, options?, client = request)` typed wrapper
- `admin/src/components/common/ImageUploader.vue` — 上传组件 SFC
- `admin/scripts/check-image-uploader.ts` — 22 项断言

## 验证

- `cd admin && npx vue-tsc --noEmit` 通过
- `cd admin && npx tsx scripts/check-image-uploader.ts` → `PASS`
- 手测建议:在 dashboard 临时挂 `<ImageUploader v-model="cover" />`,拖拽 PNG 验证 url 回填,删除同步移除 modelValue

## TODO/边界

- 仅校验 MIME 与体积,不做尺寸 / 比例裁剪;裁剪需求由业务页接 cropper 类组件
- multiple 时 url 顺序按上传完成顺序追加,如需排序可由业务侧拖拽 wrap

Closes #50