### PR TITLE
feat(admin): T2.24 权限管理页

### DIFF
--- a/admin/src/router/index.ts
+++ b/admin/src/router/index.ts
@@ -47,6 +47,12 @@ const router = createRouter({
           component: () => import('../views/rbac/roles/index.vue'),
           meta: { permission: 'role:assign' },
         },
+        {
+          path: '/cms/rbac/permissions',
+          name: 'rbac-permissions',
+          component: () => import('../views/rbac/permissions/index.vue'),
+          meta: { permission: 'role:assign' },
+        },
       ],
     },
   ],

--- a/admin/src/views/rbac/permissions/index.vue
+++ b/admin/src/views/rbac/permissions/index.vue
@@ -1,0 +1,224 @@
+<script setup lang="ts">
+// 权限管理页 — T2.24
+// 设计文档:docs/09-phase2-rbac-frontend-plan.md §4
+//
+// 偏离设计文档之处:
+// (B) 用 :fetch 而非 :api(对齐实际 DataTable 实现)
+// (C) resource 筛选放进 query reactive,DataTable 内部 useTable 的 watch 自动 reset+refresh
+//     不再需要外部 filterResource ref + 手动调 fetch
+// (K) 后端不分页(返回所有 items),前端包一层把 { items, total } 转 { list, total }
+// (L) 后端 listPermissions / updatePermission 都是 role:assign 权限码,故路由 meta 用 role:assign
+
+import { computed, h, reactive, ref, type VNode } from 'vue'
+import {
+  NButton,
+  NInput,
+  NSelect,
+  NSpace,
+  useMessage,
+  type DataTableColumns,
+} from 'naive-ui'
+import PageHeader from '../../../components/common/PageHeader.vue'
+import DataTable from '../../../components/common/DataTable.vue'
+import {
+  apiGetPermissions,
+  apiUpdatePermission,
+  type PermissionItem,
+} from '../../../api/rbac'
+import { usePermissionStore } from '../../../stores/permission'
+
+const message = useMessage()
+const permissionStore = usePermissionStore()
+
+// ---- DataTable query (resource 筛选) ----
+interface PermissionQuery {
+  resource: string
+}
+const initialQuery: PermissionQuery = { resource: '' }
+
+// 后端不分页,前端包一层把 { items, total } 转 { list, total }
+const fetchPermissions = async (
+  params: PermissionQuery & { page: number; pageSize: number },
+) => {
+  const res = await apiGetPermissions({
+    resource: params.resource || undefined,
+  })
+  return { list: res.items, total: res.total }
+}
+
+const tableRef = ref<{
+  refresh: () => Promise<void>
+  reset: () => void
+  clearSelection: () => void
+} | null>(null)
+
+function refreshTable() {
+  tableRef.value?.refresh()
+}
+
+// ---- 资源选项(从全量权限去重)----
+const resourceOptions = ref<Array<{ label: string; value: string }>>([])
+async function loadResourceOptions() {
+  const res = await apiGetPermissions()
+  const set = new Set<string>()
+  res.items.forEach((p) => set.add(p.resource))
+  resourceOptions.value = Array.from(set).map((r) => ({ label: r, value: r }))
+}
+loadResourceOptions()
+
+// ---- 行内编辑 ----
+const editingRow = ref<number | null>(null)
+const saving = ref(false)
+const editingForm = reactive({
+  name: '',
+  description: '',
+})
+
+function startEdit(row: PermissionItem) {
+  editingRow.value = row.id
+  editingForm.name = row.name
+  editingForm.description = row.description ?? ''
+}
+
+function cancelEdit() {
+  editingRow.value = null
+  editingForm.name = ''
+  editingForm.description = ''
+}
+
+async function saveEdit(row: PermissionItem) {
+  if (!editingForm.name.trim()) {
+    message.error('名称不能为空')
+    return
+  }
+  saving.value = true
+  try {
+    await apiUpdatePermission(row.id, {
+      name: editingForm.name.trim(),
+      description: editingForm.description.trim() || undefined,
+    })
+    message.success('已保存')
+    editingRow.value = null
+    refreshTable()
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : '保存失败'
+    message.error(msg)
+  } finally {
+    saving.value = false
+  }
+}
+
+// ---- 列定义 ----
+const columns = computed<DataTableColumns<PermissionItem>>(() => [
+  { title: 'ID', key: 'id', width: 70 },
+  { title: '编码', key: 'code', width: 180 },
+  { title: '资源', key: 'resource', width: 120 },
+  { title: '动作', key: 'action', width: 120 },
+  {
+    title: '名称',
+    key: 'name',
+    width: 200,
+    render(row: PermissionItem) {
+      if (editingRow.value === row.id) {
+        return h(NInput, {
+          value: editingForm.name,
+          'onUpdate:value': (v: string) => {
+            editingForm.name = v
+          },
+          placeholder: '权限名称',
+          size: 'small',
+        })
+      }
+      return row.name
+    },
+  },
+  {
+    title: '描述',
+    key: 'description',
+    ellipsis: { tooltip: true },
+    render(row: PermissionItem) {
+      if (editingRow.value === row.id) {
+        return h(NInput, {
+          value: editingForm.description,
+          'onUpdate:value': (v: string) => {
+            editingForm.description = v
+          },
+          placeholder: '可选',
+          size: 'small',
+        })
+      }
+      return row.description || h('span', { style: 'color: #999' }, '—')
+    },
+  },
+  {
+    title: '操作',
+    key: 'actions',
+    width: 140,
+    fixed: 'right',
+    render(row: PermissionItem) {
+      const canEdit = permissionStore.hasPermission('role:assign')
+      if (!canEdit) return h('span', { style: 'color: #999' }, '—')
+      const buttons: VNode[] = []
+      if (editingRow.value === row.id) {
+        buttons.push(
+          h(
+            NButton,
+            {
+              size: 'small',
+              type: 'primary',
+              loading: saving.value,
+              onClick: () => saveEdit(row),
+            },
+            { default: () => '保存' },
+          ),
+        )
+        buttons.push(
+          h(
+            NButton,
+            { size: 'small', disabled: saving.value, onClick: cancelEdit },
+            { default: () => '取消' },
+          ),
+        )
+      } else {
+        buttons.push(
+          h(
+            NButton,
+            {
+              size: 'small',
+              disabled: editingRow.value !== null,
+              onClick: () => startEdit(row),
+            },
+            { default: () => '编辑' },
+          ),
+        )
+      }
+      return h(NSpace, { size: 4 }, { default: () => buttons })
+    },
+  },
+])
+</script>
+
+<template>
+  <div>
+    <PageHeader title="权限管理" subtitle="查看并编辑权限的名称与描述(系统级,seed 维护)" />
+
+    <DataTable
+      ref="tableRef"
+      :columns="columns"
+      :fetch="fetchPermissions"
+      :initial-query="initialQuery"
+      :row-key="(row: PermissionItem) => row.id"
+    >
+      <template #search="{ query }">
+        <NSelect
+          :value="(query as PermissionQuery).resource"
+          :options="resourceOptions"
+          placeholder="资源筛选"
+          clearable
+          style="width: 180px"
+          @update:value="(v: string | null) => ((query as PermissionQuery).resource = v ?? '')"
+        />
+      </template>
+    </DataTable>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

- 新增 `/cms/rbac/permissions` 路由,权限码 `role:assign`(对齐后端 `listPermissions / updatePermission` 的 `requirePermission` 设置)
- 新增权限管理页 `admin/src/views/rbac/permissions/index.vue`,实现 7 列只读列表 + 名称/描述行内编辑 + 资源筛选
- 没有新建/删除按钮 —— 权限是系统级别,靠 seed 维护

## 偏离设计文档说明

- (B) 用 `:fetch` 而非 `:api`(对齐实际 DataTable 实现)
- (C) `resource` 筛选放进 `query` reactive,DataTable 内部 useTable 的 watch 自动刷新;不再需要外部 `filterResource ref`
- (K) 后端不分页,前端包一层把 `{ items, total }` 转 `{ list, total }`

## 行内编辑机制

- 同时只允许一行进入编辑态(其它行的"编辑"按钮置灰)
- 保存通过 `apiUpdatePermission(id, { name, description })`,成功后 `tableRef.refresh()`
- 取消会清空临时 form

## Test plan

- [x] `npx vue-tsc --noEmit` 通过(exit 0)
- [x] `npm run dev` 启动,`/src/views/rbac/permissions/index.vue` 转译 200 OK
- [ ] 浏览器手验:打开 `/cms/rbac/permissions`,数据列表加载、行内编辑名称、保存后看到刷新的名称
- [ ] 资源筛选下拉切换后表格自动刷新
- [ ] 取消编辑回到只读态,保留原值

设计文档:`docs/09-phase2-rbac-frontend-plan.md` §4

🤖 Generated with [Claude Code](https://claude.com/claude-code)