### PR TITLE
feat(admin): T2.27 文章新建/编辑页 + 修复 apiUpload 字段名

### DIFF
--- a/admin/src/api/cms.ts
+++ b/admin/src/api/cms.ts
@@ -6,7 +6,7 @@
 // (P8) 设计文档 §0.1 写 list API 返回 `{ list, total }`;后端真实返回是 `{ items, total }`,
 //      与 rbac.ts 一致。这里沿用 `{ items, total }`,view 里包一层把 items→list 转给 useTable。
 // (P4) apiUpload 字段名要发 'image'(对齐后端 multer.single("image")),
-//      不是设计文档默认的 'file'。T2.27 PR 修复。
+//      不是设计文档默认的 'file'。T2.27 PR 修复(本次)。
 //
 // 响应包装:request.ts 拦截器返回原始 AxiosResponse,所以这里走 `res.data.data`
 // 拿到真正的业务数据。
@@ -38,7 +38,7 @@ export async function apiUpload(
   client: AxiosInstance = request,
 ): Promise<UploadResultData> {
   const form = new FormData()
-  form.append('file', file)
+  form.append('image', file)
 
   const res = await client.post<ApiResponse<UploadResultData>>(
     '/api/v2/admin/cms/upload',

--- a/admin/src/components/common/markdownEditorLogic.ts
+++ b/admin/src/components/common/markdownEditorLogic.ts
@@ -8,7 +8,8 @@
 import type { TokenStore } from '../../api/tokenStorage'
 
 export const UPLOAD_URL = '/api/v2/admin/cms/upload'
-export const UPLOAD_FIELD_NAME = 'file'
+// (P4) 对齐后端 multer.single("image"),T2.27 修复。
+export const UPLOAD_FIELD_NAME = 'image'
 export const UPLOAD_MAX_BYTES = 10 * 1024 * 1024
 
 interface BackendUploadResponse {

--- a/admin/src/router/index.ts
+++ b/admin/src/router/index.ts
@@ -60,6 +60,18 @@ const router = createRouter({
           meta: { permission: 'post:list' },
         },
         {
+          path: '/cms/posts/new',
+          name: 'cms-post-new',
+          component: () => import('../views/cms/posts/edit.vue'),
+          meta: { permission: 'post:create' },
+        },
+        {
+          path: '/cms/posts/:id/edit',
+          name: 'cms-post-edit',
+          component: () => import('../views/cms/posts/edit.vue'),
+          meta: { permission: 'post:update' },
+        },
+        {
           path: '/cms/rbac/users',
           name: 'rbac-users',
           component: () => import('../views/rbac/users/index.vue'),

--- a/admin/src/views/cms/posts/edit.vue
+++ b/admin/src/views/cms/posts/edit.vue
@@ -1,0 +1,359 @@
+<script setup lang="ts">
+// 文章新建 / 编辑页 — T2.27
+// 设计文档:docs/10-phase2-cms-frontend-plan.md §6
+//
+// 偏离设计文档之处:
+// (P3) 路由用 /cms/posts/new 与 /cms/posts/:id/edit(带 cms 前缀),与 menus seed 对齐
+// (P4) 同 PR 顺带修 apiUpload 字段名 'file' → 'image' 与 MarkdownEditor UPLOAD_FIELD_NAME,
+//      使图片上传(封面 + 正文图)能真正生效
+// (P13) "离开页面前提示未保存" 设计文档没明确写,本版加 onBeforeRouteLeave + beforeunload
+//       双重拦截。dirty 标记由浅 watch 表单字段管理。
+
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  reactive,
+  ref,
+  watch,
+} from 'vue'
+import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router'
+import axios from 'axios'
+import {
+  NButton,
+  NForm,
+  NFormItem,
+  NInput,
+  NSelect,
+  NSpace,
+  NSpin,
+  useDialog,
+  useMessage,
+  type FormInst,
+  type FormRules,
+  type SelectOption,
+} from 'naive-ui'
+import PageHeader from '../../../components/common/PageHeader.vue'
+import ImageUploader from '../../../components/common/ImageUploader.vue'
+import MarkdownEditor from '../../../components/common/MarkdownEditor.vue'
+import {
+  apiGetPost,
+  apiCreatePost,
+  apiUpdatePost,
+  apiPublishPost,
+  apiUnpublishPost,
+  apiGetTags,
+  apiGetCategories,
+  type PostStatus,
+} from '../../../api/cms'
+
+const route = useRoute()
+const router = useRouter()
+const message = useMessage()
+const dialog = useDialog()
+
+// ---- 路由识别新建 / 编辑 ----
+const editingId = computed(() => {
+  const id = route.params.id
+  if (!id) return null
+  const n = Number(id)
+  return Number.isFinite(n) && n > 0 ? n : null
+})
+const isEdit = computed(() => editingId.value !== null)
+
+// ---- 表单 ----
+interface PostForm {
+  title: string
+  slug: string
+  excerpt: string
+  coverImageUrl: string
+  contentMarkdown: string
+  tags: string[]
+  categories: string[]
+}
+
+const initialForm = (): PostForm => ({
+  title: '',
+  slug: '',
+  excerpt: '',
+  coverImageUrl: '',
+  contentMarkdown: '',
+  tags: [],
+  categories: [],
+})
+
+const form = reactive<PostForm>(initialForm())
+const formRef = ref<FormInst | null>(null)
+const loading = ref(false)
+const submitting = ref(false)
+const currentStatus = ref<PostStatus>('draft')
+const dirty = ref(false)
+let suppressDirty = true // 加载阶段不计入 dirty
+
+// 监听整个 form,任意字段变化即标脏(加载完成后)
+watch(
+  form,
+  () => {
+    if (suppressDirty) return
+    dirty.value = true
+  },
+  { deep: true },
+)
+
+const formRules = computed<FormRules>(() => ({
+  title: [
+    { required: true, message: '请输入标题', trigger: 'blur' },
+    { max: 200, message: '标题不能超过 200 字', trigger: 'blur' },
+  ],
+  slug: [
+    {
+      trigger: 'blur',
+      validator: (_rule: unknown, value: string) => {
+        if (!value) return true
+        if (!/^[a-z0-9][a-z0-9-]*$/.test(value)) {
+          return new Error('slug 须以小写字母或数字开头,只含小写字母 / 数字 / 连字符')
+        }
+        return true
+      },
+    },
+  ],
+  excerpt: [{ max: 500, message: '摘要不能超过 500 字', trigger: 'blur' }],
+}))
+
+// ---- 标签 / 分类候选 ----
+const tagOptions = ref<SelectOption[]>([])
+const categoryOptions = ref<SelectOption[]>([])
+
+async function loadOptions() {
+  try {
+    const [tagsRes, catsRes] = await Promise.all([apiGetTags(), apiGetCategories()])
+    tagOptions.value = tagsRes.items.map((t) => ({ label: t.name, value: t.name }))
+    categoryOptions.value = catsRes.items.map((c) => ({ label: c.name, value: c.name }))
+  } catch {
+    // 不阻塞,候选取不到时让用户手动输入即可
+  }
+}
+
+// ---- 加载已有文章 ----
+async function loadPost() {
+  if (!editingId.value) return
+  loading.value = true
+  try {
+    const detail = await apiGetPost(editingId.value)
+    form.title = detail.title
+    form.slug = detail.slug
+    form.excerpt = detail.excerpt ?? ''
+    form.coverImageUrl = detail.coverImageUrl ?? ''
+    form.contentMarkdown = detail.contentMarkdown ?? ''
+    form.tags = detail.tags.map((t) => t.name)
+    form.categories = detail.categories.map((c) => c.name)
+    currentStatus.value = detail.status
+  } catch (e: unknown) {
+    message.error(extractError(e, '加载文章失败'))
+  } finally {
+    loading.value = false
+  }
+}
+
+function extractError(e: unknown, fallback: string): string {
+  if (axios.isAxiosError(e)) {
+    const data = e.response?.data as { message?: string } | undefined
+    if (data?.message === 'slug_taken') return '该 slug 已被占用'
+    if (data?.message) return data.message
+  }
+  if (e instanceof Error) return e.message
+  return fallback
+}
+
+// ---- 保存 ----
+async function doSave(targetStatus: PostStatus): Promise<boolean> {
+  if (!formRef.value) return false
+  try {
+    await formRef.value.validate()
+  } catch {
+    return false
+  }
+  submitting.value = true
+  try {
+    const payload = {
+      title: form.title,
+      slug: form.slug || undefined,
+      excerpt: form.excerpt || undefined,
+      coverImageUrl: form.coverImageUrl || undefined,
+      contentMarkdown: form.contentMarkdown || undefined,
+      tags: form.tags,
+      categories: form.categories,
+    }
+
+    let savedId: number
+    if (isEdit.value && editingId.value !== null) {
+      // 编辑:先 PUT 字段,再按需切状态
+      const updated = await apiUpdatePost(editingId.value, payload)
+      savedId = updated.id
+      if (targetStatus === 'published' && currentStatus.value !== 'published') {
+        await apiPublishPost(savedId)
+        currentStatus.value = 'published'
+      } else if (targetStatus === 'draft' && currentStatus.value === 'published') {
+        await apiUnpublishPost(savedId)
+        currentStatus.value = 'draft'
+      } else {
+        currentStatus.value = updated.status
+      }
+    } else {
+      // 新建:POST 默认 draft,然后按需 publish
+      const created = await apiCreatePost({ ...payload, status: 'draft' })
+      savedId = created.id
+      currentStatus.value = created.status
+      if (targetStatus === 'published') {
+        await apiPublishPost(savedId)
+        currentStatus.value = 'published'
+      }
+    }
+
+    message.success(targetStatus === 'published' ? '已发布' : '草稿已保存')
+    dirty.value = false
+    return true
+  } catch (e: unknown) {
+    message.error(extractError(e, '保存失败'))
+    return false
+  } finally {
+    submitting.value = false
+  }
+}
+
+async function handleSaveDraft() {
+  const ok = await doSave('draft')
+  if (ok) router.push({ name: 'cms-posts' })
+}
+
+async function handlePublish() {
+  const ok = await doSave('published')
+  if (ok) router.push({ name: 'cms-posts' })
+}
+
+function handleCancel() {
+  router.push({ name: 'cms-posts' })
+}
+
+// ---- 离开页面拦截 ----
+function onBeforeUnload(e: BeforeUnloadEvent) {
+  if (!dirty.value) return
+  e.preventDefault()
+  e.returnValue = ''
+}
+
+onBeforeRouteLeave((_to, _from, next) => {
+  if (!dirty.value) {
+    next()
+    return
+  }
+  dialog.warning({
+    title: '有未保存的修改',
+    content: '当前修改尚未保存,确定要离开吗?',
+    positiveText: '离开',
+    negativeText: '继续编辑',
+    onPositiveClick: () => next(true),
+    onNegativeClick: () => next(false),
+    onClose: () => next(false),
+    onMaskClick: () => next(false),
+  })
+})
+
+onMounted(async () => {
+  window.addEventListener('beforeunload', onBeforeUnload)
+  await Promise.all([loadOptions(), loadPost()])
+  // 等下一个 tick 解锁 dirty 监听
+  setTimeout(() => {
+    suppressDirty = false
+  }, 0)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('beforeunload', onBeforeUnload)
+})
+
+const headerTitle = computed(() => (isEdit.value ? '编辑文章' : '新建文章'))
+const headerSubtitle = computed(() =>
+  isEdit.value
+    ? `文章 ID #${editingId.value}(当前${currentStatus.value === 'published' ? '已发布' : '草稿'})`
+    : '撰写新文章',
+)
+</script>
+
+<template>
+  <div>
+    <PageHeader :title="headerTitle" :subtitle="headerSubtitle">
+      <NSpace>
+        <NButton @click="handleCancel">取消</NButton>
+        <NButton :loading="submitting" @click="handleSaveDraft">
+          保存草稿
+        </NButton>
+        <NButton type="primary" :loading="submitting" @click="handlePublish">
+          {{ currentStatus === 'published' ? '保存并保持发布' : '发布' }}
+        </NButton>
+      </NSpace>
+    </PageHeader>
+
+    <NSpin :show="loading">
+      <NForm
+        ref="formRef"
+        :model="form"
+        :rules="formRules"
+        label-placement="left"
+        label-width="100"
+        require-mark-placement="right-hanging"
+        style="max-width: 960px"
+      >
+        <NFormItem label="标题" path="title">
+          <NInput v-model:value="form.title" placeholder="请输入文章标题" />
+        </NFormItem>
+
+        <NFormItem label="Slug" path="slug">
+          <NInput
+            v-model:value="form.slug"
+            placeholder="可选,留空将由标题自动生成"
+          />
+        </NFormItem>
+
+        <NFormItem label="摘要" path="excerpt">
+          <NInput
+            v-model:value="form.excerpt"
+            type="textarea"
+            placeholder="可选,显示在列表卡片"
+            :autosize="{ minRows: 2, maxRows: 4 }"
+          />
+        </NFormItem>
+
+        <NFormItem label="封面图" path="coverImageUrl">
+          <ImageUploader v-model="form.coverImageUrl" />
+        </NFormItem>
+
+        <NFormItem label="标签">
+          <NSelect
+            v-model:value="form.tags"
+            multiple
+            tag
+            filterable
+            :options="tagOptions"
+            placeholder="选择已有标签或输入新标签按回车"
+          />
+        </NFormItem>
+
+        <NFormItem label="分类">
+          <NSelect
+            v-model:value="form.categories"
+            multiple
+            tag
+            filterable
+            :options="categoryOptions"
+            placeholder="选择已有分类或输入新分类按回车"
+          />
+        </NFormItem>
+
+        <NFormItem label="正文" path="contentMarkdown">
+          <MarkdownEditor v-model="form.contentMarkdown" :height="500" />
+        </NFormItem>
+      </NForm>
+    </NSpin>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

新增 /cms/posts/new + /cms/posts/:id/edit 表单页(Phase 2 §5.1.5 第 5 个 PR)

- 字段:title / slug / excerpt / 封面图 / 标签 / 分类 / 正文 Markdown
- 操作:保存草稿 / 发布 / 取消
- 离开页面拦截:onBeforeRouteLeave + window.beforeunload(双保险)

**同 PR 顺带修复图片上传字段名 'file' → 'image' (P4)**:
- \`admin/src/api/cms.ts\` — apiUpload form.append 字段
- \`admin/src/components/common/markdownEditorLogic.ts\` — UPLOAD_FIELD_NAME

后端是 \`multer.single("image")\`,前端两处此前都发的 'file' → 任何上传都返 400。本 PR 是首个真用上传的页面,与功能耦合一起修。

## 设计文档偏离

| 标号 | 偏离 | 落点 |
|---|---|---|
| P3 | 路由 /posts/new、/posts/:id/edit | 用 /cms/posts/new、/cms/posts/:id/edit,与 menus seed 对齐 |
| P4 | apiUpload 字段未提及 | 修字段名 'file' → 'image',MarkdownEditor 同步修 |
| **P13** | 离开页面拦截设计文档没明确写 | 本版加 onBeforeRouteLeave + beforeunload,deep watch 表单管理 dirty |

## 体验细节

- 编辑模式下顶部 subtitle 显示 \`文章 ID #N(当前已发布/草稿)\`
- 主按钮文案随状态变化:草稿 → "发布",已发布 → "保存并保持发布"(避免误改 publishedAt)
- 编辑切草稿走 apiUnpublishPost;新建+点发布走 POST(draft) → publish 两步
- 标签/分类候选预拉,网络异常时不阻塞(可手输)
- dirty 标记 onMounted 后才解锁,避免初始加载误标脏

## Test plan

- [x] \`npx vite build\` ✅(edit-*.js 346 kB,Vditor 占大头)
- [x] \`npx vue-tsc --noEmit\` ✅ EXIT=0
- [ ] 新建一篇文章 + 上传封面图(验证 P4 修复)
- [ ] 正文里粘贴/拖拽图片上传(验证 markdownEditorLogic P4 修复)
- [ ] 编辑已发布文章,切回草稿,确认 publishedAt 保留行为(后端语义)
- [ ] 修改后不保存关闭 tab → 浏览器原生提示
- [ ] 修改后不保存点 sidebar 其他菜单 → dialog 拦截

🤖 Generated with [Claude Code](https://claude.com/claude-code)