### PR TITLE
feat(admin): T2.31 媒体库 MVP

### DIFF
--- a/admin/src/router/index.ts
+++ b/admin/src/router/index.ts
@@ -72,6 +72,12 @@ const router = createRouter({
           meta: { permission: 'post:update' },
         },
         {
+          path: '/cms/media',
+          name: 'cms-media',
+          component: () => import('../views/cms/media/index.vue'),
+          meta: { permission: 'post:list' },
+        },
+        {
           path: '/cms/rbac/users',
           name: 'rbac-users',
           component: () => import('../views/rbac/users/index.vue'),

--- a/admin/src/views/cms/media/index.vue
+++ b/admin/src/views/cms/media/index.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+// 媒体库 MVP — T2.31
+// 设计文档:docs/10-phase2-cms-frontend-plan.md §7
+//
+// 偏离设计文档之处:
+// (P3) 路由用 /cms/media(带 cms 前缀),与 menus seed 对齐
+// (P6) MVP 方案 A:仅上传弹窗 + 复制 URL,后端尚无 media 表与 list API,
+//      历史网格暂用 n-empty 占位。后端补 GET /api/v2/admin/cms/media 后再接入网格,
+//      issue #61 关闭时附 follow-up TODO
+
+import { ref } from 'vue'
+import {
+  NButton,
+  NCard,
+  NEmpty,
+  NIcon,
+  NImage,
+  NInput,
+  NModal,
+  NSpace,
+  NText,
+  useMessage,
+} from 'naive-ui'
+import { CloudUploadOutline, CopyOutline } from '@vicons/ionicons5'
+import PageHeader from '../../../components/common/PageHeader.vue'
+import ImageUploader from '../../../components/common/ImageUploader.vue'
+
+const message = useMessage()
+const showUploadModal = ref(false)
+const uploadedUrls = ref<string[]>([])
+// ImageUploader v-model:多图模式下绑 string[]
+const tempUrls = ref<string[]>([])
+
+function openUploader() {
+  tempUrls.value = []
+  showUploadModal.value = true
+}
+
+function handleUploaderChange(value: string | string[]) {
+  if (Array.isArray(value)) {
+    tempUrls.value = value
+  } else {
+    tempUrls.value = value ? [value] : []
+  }
+}
+
+function handleConfirm() {
+  // 把本次新上传的合入"本次会话内"列表(顶部插入,去重)
+  const merged = [...tempUrls.value]
+  for (const u of uploadedUrls.value) {
+    if (!merged.includes(u)) merged.push(u)
+  }
+  uploadedUrls.value = merged
+  showUploadModal.value = false
+  if (tempUrls.value.length > 0) {
+    message.success(`成功上传 ${tempUrls.value.length} 张图片`)
+  }
+}
+
+async function copyUrl(url: string) {
+  try {
+    await navigator.clipboard.writeText(url)
+    message.success('已复制 URL')
+  } catch {
+    // Fallback:旧浏览器/非 https
+    const input = document.createElement('input')
+    input.value = url
+    document.body.appendChild(input)
+    input.select()
+    document.execCommand('copy')
+    document.body.removeChild(input)
+    message.success('已复制 URL')
+  }
+}
+</script>
+
+<template>
+  <div>
+    <PageHeader title="媒体库" subtitle="管理上传的图片资源(MVP:本次会话内列表 + 上传 + 复制 URL)">
+      <NButton type="primary" @click="openUploader">
+        <template #icon>
+          <NIcon><CloudUploadOutline /></NIcon>
+        </template>
+        上传图片
+      </NButton>
+    </PageHeader>
+
+    <NCard>
+      <template v-if="uploadedUrls.length === 0">
+        <NEmpty description="暂无图片记录">
+          <template #extra>
+            <NText depth="3" style="font-size: 12px">
+              点击右上角"上传图片"按钮开始。后端 media 列表接口建设中,
+              本次会话内上传的 URL 会临时保留在此页便于复制使用。
+            </NText>
+          </template>
+        </NEmpty>
+      </template>
+
+      <template v-else>
+        <NSpace vertical size="medium">
+          <NText depth="2">本次会话上传记录(刷新页面后丢失,后端补 list 接口后切真历史):</NText>
+          <NSpace
+            v-for="url in uploadedUrls"
+            :key="url"
+            align="center"
+            style="width: 100%"
+          >
+            <NImage :src="url" width="64" height="64" object-fit="cover" />
+            <NInput :value="url" readonly style="width: 480px" />
+            <NButton size="small" @click="copyUrl(url)">
+              <template #icon>
+                <NIcon><CopyOutline /></NIcon>
+              </template>
+              复制
+            </NButton>
+          </NSpace>
+        </NSpace>
+      </template>
+    </NCard>
+
+    <NModal
+      v-model:show="showUploadModal"
+      preset="card"
+      title="上传图片"
+      style="width: 640px"
+      :bordered="false"
+    >
+      <ImageUploader
+        :model-value="tempUrls"
+        multiple
+        :max="10"
+        @update:model-value="handleUploaderChange"
+      />
+      <template #footer>
+        <NSpace justify="end">
+          <NButton @click="showUploadModal = false">取消</NButton>
+          <NButton type="primary" @click="handleConfirm">完成</NButton>
+        </NSpace>
+      </template>
+    </NModal>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

新增 /cms/media 媒体库页 MVP(Phase 2 §5.1.5 第 6 个 PR)

按设计文档 §7.2 方案 A:
- 顶部"上传图片" → 弹窗 ImageUploader(multiple, max=10)
- 上传成功后,本次会话内 URL 列表展示:缩略图 + URL 输入框 + 复制按钮
- 历史网格用 NEmpty 占位

## 设计文档偏离

| 标号 | 偏离 | 落点 |
|---|---|---|
| P3 | 路由 /media | 用 /cms/media,与 menus seed 对齐 |
| **P6** | issue #61 验收"网格展示 + 搜索 + 操作" | 后端尚无 media 表与 list API,本次为方案 A MVP,会话内 URL 列表临时方案,刷新页面丢失 |

## Follow-up(关 issue 时附)

后端补 \`GET /api/v2/admin/cms/media\`(分页 + 列表 + 删除)后:
1. 网格替换 NEmpty 占位
2. 增加批量删除
3. 与文章/封面图反向引用统计

## 权限

- 路由 \`post:list\`(与 seed "博客管理 → 媒体库"菜单一致)
- 实际上传走后端 \`/api/v2/admin/cms/upload\`,中间件 \`requirePermission('media:upload')\` 把关

## Test plan

- [x] \`npx vite build\` ✅
- [x] \`npx vue-tsc --noEmit\` ✅ EXIT=0
- [ ] super_admin 登录,sidebar "博客管理 → 媒体库" 可点
- [ ] 上传 1-3 张图,确认 URL 出现 + 复制按钮工作
- [ ] viewer 登录,菜单仍可见(post:list 权限),上传弹窗按钮可点但实际上传应被后端 403 拒绝

🤖 Generated with [Claude Code](https://claude.com/claude-code)