### PR TITLE
feat: KB导入仅处理wiki子目录 + 解析YAML表头提取结构化字段

### DIFF
--- a/admin/src/api/kb.ts
+++ b/admin/src/api/kb.ts
@@ -13,6 +13,10 @@ export interface KbDocumentListItem {
   source: 'obsidian' | 'manual' | 'api'
   tags: string[]
   status: 'active' | 'archived'
+  category: string | null
+  doc_type: 'entity' | 'concept' | 'source' | 'synthesis' | null
+  doc_date: string | null
+  review_status: 'seed' | 'developing' | 'mature' | null
   word_count: number
   created_at: string
   updated_at: string
@@ -23,6 +27,8 @@ export interface KbDocumentDetail extends KbDocumentListItem {
   content_html: string | null
   original_path: string | null
   checksum: string | null
+  connections: string[]
+  sources: string[]
 }
 
 export interface KbDocumentQuery {
@@ -31,6 +37,7 @@ export interface KbDocumentQuery {
   source?: string
   status?: string
   tag?: string
+  category?: string
   sortBy?: 'updated_at' | 'created_at' | 'title' | 'word_count'
   sortDir?: 'asc' | 'desc'
 }
@@ -43,6 +50,13 @@ export async function apiListKbDocuments(
     '/api/v2/admin/kb/documents',
     { params },
   )
+  return res.data.data
+}
+
+export async function apiListKbDocumentCategories(
+  client: AxiosInstance = request,
+): Promise<string[]> {
+  const res = await client.get<ApiResponse<string[]>>('/api/v2/admin/kb/documents/categories')
   return res.data.data
 }
 
@@ -60,6 +74,12 @@ export interface CreateKbDocumentPayload {
   excerpt?: string
   content_markdown?: string
   tags?: string[]
+  category?: string
+  doc_type?: string
+  connections?: string[]
+  sources?: string[]
+  doc_date?: string
+  review_status?: string
 }
 
 export async function apiCreateKbDocument(
@@ -78,6 +98,12 @@ export interface UpdateKbDocumentPayload {
   tags?: string[]
   source?: string
   status?: string
+  category?: string
+  doc_type?: string
+  connections?: string[]
+  sources?: string[]
+  doc_date?: string
+  review_status?: string
 }
 
 export async function apiUpdateKbDocument(

--- a/admin/src/views/kb/documents/edit.vue
+++ b/admin/src/views/kb/documents/edit.vue
@@ -42,6 +42,12 @@ interface DocForm {
   excerpt: string
   content_markdown: string
   tags: string[]
+  category: string
+  doc_type: string
+  connections: string[]
+  sources: string[]
+  doc_date: string
+  review_status: string
 }
 
 const initialForm = (): DocForm => ({
@@ -50,6 +56,12 @@ const initialForm = (): DocForm => ({
   excerpt: '',
   content_markdown: '',
   tags: [],
+  category: '',
+  doc_type: '',
+  connections: [],
+  sources: [],
+  doc_date: '',
+  review_status: '',
 })
 
 const form = reactive<DocForm>(initialForm())
@@ -95,6 +107,12 @@ async function loadDocument() {
     form.excerpt = detail.excerpt ?? ''
     form.content_markdown = detail.content_markdown ?? ''
     form.tags = detail.tags ?? []
+    form.category = detail.category ?? ''
+    form.doc_type = detail.doc_type ?? ''
+    form.connections = detail.connections ?? []
+    form.sources = detail.sources ?? []
+    form.doc_date = detail.doc_date ?? ''
+    form.review_status = detail.review_status ?? ''
   } catch (e: unknown) {
     message.error(extractError(e, '加载文档失败'))
   } finally {
@@ -127,6 +145,12 @@ async function doSave(): Promise<boolean> {
       excerpt: form.excerpt || undefined,
       content_markdown: form.content_markdown || undefined,
       tags: form.tags,
+      category: form.category || undefined,
+      doc_type: form.doc_type || undefined,
+      connections: form.connections,
+      sources: form.sources,
+      doc_date: form.doc_date || undefined,
+      review_status: form.review_status || undefined,
     }
 
     if (isEdit.value && editingId.value !== null) {
@@ -240,6 +264,61 @@ const headerSubtitle = computed(() => isEdit.value ? `文档 ID #${editingId.val
               tag
               filterable
               placeholder="输入标签回车添加"
+            />
+          </NFormItem>
+
+          <NFormItem label="分类">
+            <NInput v-model:value="form.category" placeholder="文档分类（如: notes, concepts）" />
+          </NFormItem>
+
+          <NFormItem label="文档类型">
+            <NSelect
+              v-model:value="form.doc_type"
+              clearable
+              placeholder="选择类型"
+              :options="[
+                { label: '实体 (entity)', value: 'entity' },
+                { label: '概念 (concept)', value: 'concept' },
+                { label: '来源 (source)', value: 'source' },
+                { label: '综合 (synthesis)', value: 'synthesis' },
+              ]"
+            />
+          </NFormItem>
+
+          <NFormItem label="关联页面">
+            <NSelect
+              v-model:value="form.connections"
+              multiple
+              tag
+              filterable
+              placeholder="输入关联页面名回车添加"
+            />
+          </NFormItem>
+
+          <NFormItem label="来源文件">
+            <NSelect
+              v-model:value="form.sources"
+              multiple
+              tag
+              filterable
+              placeholder="输入源文件名回车添加"
+            />
+          </NFormItem>
+
+          <NFormItem label="文档日期">
+            <NInput v-model:value="form.doc_date" placeholder="YYYY-MM-DD" />
+          </NFormItem>
+
+          <NFormItem label="成熟度">
+            <NSelect
+              v-model:value="form.review_status"
+              clearable
+              placeholder="选择状态"
+              :options="[
+                { label: '草稿 (seed)', value: 'seed' },
+                { label: '完善中 (developing)', value: 'developing' },
+                { label: '成熟 (mature)', value: 'mature' },
+              ]"
             />
           </NFormItem>
 

--- a/admin/src/views/kb/documents/index.vue
+++ b/admin/src/views/kb/documents/index.vue
@@ -28,6 +28,7 @@ import PageHeader from '../../../components/common/PageHeader.vue'
 import PublishDialog from '../../../components/kb/publish/PublishDialog.vue'
 import {
   apiListKbDocuments,
+  apiListKbDocumentCategories,
   apiDeleteKbDocument,
   type KbDocumentListItem,
 } from '../../../api/kb'
@@ -73,6 +74,21 @@ const table = useTable<KbDocumentListItem, DocQuery>({
   initialQuery,
   pageSize: 12,
 })
+
+const categoryOptions = ref<Array<{ label: string; value: string }>>([])
+
+async function loadCategories() {
+  try {
+    const cats = await apiListKbDocumentCategories()
+    categoryOptions.value = [
+      { label: '全部分类', value: '' },
+      ...cats.map(c => ({ label: c, value: c })),
+    ]
+  } catch {
+    categoryOptions.value = [{ label: '全部分类', value: '' }]
+  }
+}
+loadCategories()
 
 const SOURCE_OPTIONS = [
   { label: '全部来源', value: '' },
@@ -145,6 +161,14 @@ const tableColumns = computed(() => [
     width: 90,
     render(row: KbDocumentListItem) {
       return h(NTag, { size: 'small', type: sourceTagType(row.source) }, () => sourceLabel(row.source))
+    },
+  },
+  {
+    title: '分类',
+    key: 'category' as const,
+    width: 100,
+    render(row: KbDocumentListItem) {
+      return row.category ? h(NTag, { size: 'small', type: 'info' }, () => row.category) : ''
     },
   },
   {
@@ -263,6 +287,13 @@ const tableColumns = computed(() => [
         clearable
         style="width: 120px"
       />
+      <NSelect
+        v-model:value="table.query.category"
+        :options="categoryOptions"
+        placeholder="分类"
+        clearable
+        style="width: 130px"
+      />
       <NButton quaternary circle :loading="table.loading.value" @click="table.refresh()">
         <RefreshOutline class="w-4 h-4" />
       </NButton>
@@ -308,6 +339,7 @@ const tableColumns = computed(() => [
                 </span>
               </div>
               <p class="text-xs text-base-content/30 mt-1 truncate">{{ row.slug }}</p>
+              <p v-if="row.category" class="text-xs text-primary/60 mt-1">分类: {{ row.category }}</p>
 
               <!-- 标签 -->
               <div class="flex flex-wrap gap-1 mt-2.5">

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,6 +18,7 @@
         "express-session": "^1.18.2",
         "helmet": "^7.1.0",
         "joi": "^18.1.2",
+        "js-yaml": "^4.1.1",
         "jsonwebtoken": "^9.0.3",
         "marked": "^16.2.0",
         "multer": "^1.4.5-lts.1",
@@ -152,6 +153,12 @@
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -1371,6 +1378,18 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/jsonwebtoken": {

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
     "express-session": "^1.18.2",
     "helmet": "^7.1.0",
     "joi": "^18.1.2",
+    "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.3",
     "marked": "^16.2.0",
     "multer": "^1.4.5-lts.1",

--- a/server/src/apps/admin/kb/documentHandlers.js
+++ b/server/src/apps/admin/kb/documentHandlers.js
@@ -20,6 +20,10 @@ function pickDocumentListItem(row) {
     source: row.source,
     tags: parseTags(row.tags),
     status: row.status,
+    category: row.category || null,
+    doc_type: row.doc_type || null,
+    doc_date: row.doc_date || null,
+    review_status: row.review_status || null,
     word_count: row.word_count,
     created_at: row.created_at,
     updated_at: row.updated_at,
@@ -53,6 +57,8 @@ function pickDocumentPublic(row) {
     content_html: row.content_html || null,
     original_path: row.original_path || null,
     checksum: row.checksum || null,
+    connections: parseTags(row.connections),
+    sources: parseTags(row.sources),
   };
 }
 
@@ -65,6 +71,7 @@ function listDocuments(req, res) {
   const source = String(req.query.source || "").trim() || null;
   const status = String(req.query.status || "").trim() || null;
   const tag = String(req.query.tag || "").trim() || null;
+  const category = String(req.query.category || "").trim() || null;
   const sortBy = String(req.query.sortBy || "updated_at");
   const sortDir = String(req.query.sortDir || "desc").toLowerCase() === "asc" ? "ASC" : "DESC";
   const allowedSorts = new Set(["updated_at", "created_at", "title", "word_count"]);
@@ -97,6 +104,10 @@ function listDocuments(req, res) {
     where.push("tags LIKE ?");
     params.push(`%"${tag}"%`);
   }
+  if (category) {
+    where.push("category = ?");
+    params.push(category);
+  }
 
   const clause = where.join(" AND ");
   const total = db.prepare(`SELECT COUNT(*) AS c FROM kb_documents WHERE ${clause}`).get(...params).c;
@@ -104,7 +115,7 @@ function listDocuments(req, res) {
   const offset = (page - 1) * pageSize;
   const rows = db
     .prepare(`
-      SELECT id, title, slug, excerpt, source, tags, status, word_count, created_at, updated_at
+      SELECT id, title, slug, excerpt, source, tags, status, category, doc_type, doc_date, review_status, word_count, created_at, updated_at
         FROM kb_documents
        WHERE ${clause}
        ORDER BY ${orderCol} ${sortDir}, id DESC
@@ -148,13 +159,20 @@ function createDocument(req, res) {
   const createdAt = nowIso();
   const updatedAt = createdAt;
 
+  const category = String(body.category ?? "").trim() || null;
+  const docType = ["entity", "concept", "source", "synthesis"].includes(body.doc_type) ? body.doc_type : null;
+  const connections = JSON.stringify(Array.isArray(body.connections) ? body.connections.filter(Boolean) : []);
+  const sources = JSON.stringify(Array.isArray(body.sources) ? body.sources.filter(Boolean) : []);
+  const docDate = String(body.doc_date ?? "").trim() || null;
+  const reviewStatus = ["seed", "developing", "mature"].includes(body.review_status) ? body.review_status : null;
+
   try {
     const info = db
       .prepare(`
-        INSERT INTO kb_documents (title, slug, excerpt, content_markdown, content_html, source, tags, checksum, word_count, created_at, updated_at)
-        VALUES (@title, @slug, @excerpt, @content_markdown, NULL, 'manual', @tags, @checksum, @word_count, @created_at, @updated_at)
+        INSERT INTO kb_documents (title, slug, excerpt, content_markdown, content_html, source, tags, checksum, category, doc_type, connections, sources, doc_date, review_status, word_count, created_at, updated_at)
+        VALUES (@title, @slug, @excerpt, @content_markdown, NULL, 'manual', @tags, @checksum, @category, @docType, @connections, @sources, @docDate, @reviewStatus, @word_count, @createdAt, @updatedAt)
       `)
-      .run({ title, slug, excerpt, content_markdown, tags: tagsJson, checksum, word_count, created_at: createdAt, updated_at: updatedAt });
+      .run({ title, slug, excerpt, content_markdown, tags: tagsJson, checksum, category, docType, connections, sources, docDate, reviewStatus, word_count, created_at: createdAt, updated_at: updatedAt });
 
     const row = db.prepare("SELECT * FROM kb_documents WHERE id = ?").get(info.lastInsertRowid);
     auditLog(db, req, "create", info.lastInsertRowid, `创建文档: ${title}`);
@@ -194,14 +212,35 @@ function updateDocument(req, res) {
     : existing.word_count;
   const updatedAt = nowIso();
 
+  const category = body.category !== undefined
+    ? (String(body.category).trim() || null)
+    : (existing.category || null);
+  const docType = body.doc_type !== undefined
+    ? (["entity", "concept", "source", "synthesis"].includes(body.doc_type) ? body.doc_type : null)
+    : (existing.doc_type || null);
+  const connections = body.connections !== undefined
+    ? JSON.stringify(Array.isArray(body.connections) ? body.connections.filter(Boolean) : [])
+    : existing.connections;
+  const sources = body.sources !== undefined
+    ? JSON.stringify(Array.isArray(body.sources) ? body.sources.filter(Boolean) : [])
+    : existing.sources;
+  const docDate = body.doc_date !== undefined
+    ? (String(body.doc_date).trim() || null)
+    : (existing.doc_date || null);
+  const reviewStatus = body.review_status !== undefined
+    ? (["seed", "developing", "mature"].includes(body.review_status) ? body.review_status : null)
+    : (existing.review_status || null);
+
   try {
     db.prepare(`
       UPDATE kb_documents
          SET title=@title, slug=@slug, excerpt=@excerpt, content_markdown=@content_markdown,
              content_html=NULL, source=@source, tags=@tags, checksum=@checksum,
+             category=@category, doc_type=@docType, connections=@connections, sources=@sources,
+             doc_date=@docDate, review_status=@reviewStatus,
              word_count=@word_count, status=@status, updated_at=@updatedAt
        WHERE id=@id
-    `).run({ id, title, slug, excerpt, content_markdown, source, tags, checksum, word_count, status, updatedAt });
+    `).run({ id, title, slug, excerpt, content_markdown, source, tags, checksum, word_count, status, updatedAt, category, docType, connections, sources, docDate, reviewStatus });
 
     // If this document is mapped to a post with sync_enabled=1, update the post too
     const mapping = db.prepare(`
@@ -246,10 +285,20 @@ function deleteDocument(req, res) {
   return res.status(200).json({ code: 200, message: "success", data: { deleted: true } });
 }
 
+function listCategories(req, res) {
+  const db = openDb();
+  const rows = db
+    .prepare("SELECT DISTINCT category FROM kb_documents WHERE category IS NOT NULL ORDER BY category")
+    .all();
+  const categories = rows.map(r => r.category).filter(Boolean);
+  return res.status(200).json({ code: 200, message: "success", data: categories });
+}
+
 module.exports = {
   listDocuments,
   getDocument,
   createDocument,
   updateDocument,
   deleteDocument,
+  listCategories,
 };

--- a/server/src/apps/admin/kb/documentsRouter.js
+++ b/server/src/apps/admin/kb/documentsRouter.js
@@ -6,6 +6,7 @@ const requirePermission = require("../../../middleware/rbac");
 const router = express.Router();
 
 router.get("/", jwtAuth, requirePermission("kb:list"), handlers.listDocuments);
+router.get("/categories", jwtAuth, requirePermission("kb:list"), handlers.listCategories);
 router.get("/:id", jwtAuth, requirePermission("kb:list"), handlers.getDocument);
 router.post("/", jwtAuth, requirePermission("kb:create"), handlers.createDocument);
 router.put("/:id", jwtAuth, requirePermission("kb:update"), handlers.updateDocument);

--- a/server/src/apps/admin/kb/frontmatter.js
+++ b/server/src/apps/admin/kb/frontmatter.js
@@ -1,0 +1,30 @@
+const yaml = require("js-yaml");
+
+/**
+ * Parse YAML front matter from markdown content.
+ * @param {string} content - Full file content
+ * @returns {{ attributes: Object, body: string }}
+ */
+function parseFrontMatter(content) {
+  if (typeof content !== "string") return { attributes: {}, body: "" };
+
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!match) {
+    return { attributes: {}, body: content };
+  }
+
+  const yamlStr = match[1];
+  const body = content.slice(match[0].length);
+
+  try {
+    const data = yaml.load(yamlStr);
+    return {
+      attributes: (data && typeof data === "object" && !Array.isArray(data)) ? data : {},
+      body,
+    };
+  } catch {
+    return { attributes: {}, body: content };
+  }
+}
+
+module.exports = { parseFrontMatter };

--- a/server/src/apps/admin/kb/syncEngine.js
+++ b/server/src/apps/admin/kb/syncEngine.js
@@ -3,6 +3,7 @@ const path = require("path");
 const crypto = require("crypto");
 const { openDb } = require("../../../db");
 const { normalizeSlug } = require("../../../utils");
+const { parseFrontMatter } = require("./frontmatter");
 
 let _syncing = false;
 
@@ -25,13 +26,14 @@ function computeChecksum(content) {
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
 /**
- * Recursively scan a directory for .md files, returning file info with checksums.
+ * Recursively scan the wiki/ subdirectory for .md files, returning file info with checksums.
  */
 function scanVault(vaultPath) {
   const results = [];
-  if (!fs.existsSync(vaultPath)) return results;
+  const wikiPath = path.join(vaultPath, "wiki");
+  if (!fs.existsSync(wikiPath)) return results;
 
-  const resolved = path.resolve(vaultPath);
+  const resolved = path.resolve(wikiPath);
   const normalized = path.normalize(resolved);
 
   function walk(dir) {
@@ -58,7 +60,7 @@ function scanVault(vaultPath) {
           continue;
         }
         if (stat.size > MAX_FILE_SIZE) continue;
-        const relPath = path.relative(vaultPath, full).replace(/\\/g, "/");
+        const relPath = path.relative(wikiPath, full).replace(/\\/g, "/");
         const content = fs.readFileSync(full, "utf8");
         results.push({
           relativePath: relPath,
@@ -69,7 +71,7 @@ function scanVault(vaultPath) {
       }
     }
   }
-  walk(vaultPath);
+  walk(wikiPath);
   return results;
 }
 
@@ -84,10 +86,44 @@ function slugFromPath(relativePath) {
 
 /**
  * Import a single file into kb_documents.
+ * Parses YAML front matter to extract title, type, tags, connections, sources, dates, status.
  * Returns { action, id, path, detail? }
  */
 function importDocument(db, fileInfo, conflictStrategy, now, source) {
   const src = source || "obsidian";
+
+  // Parse YAML front matter
+  const { attributes, body } = parseFrontMatter(fileInfo.content);
+
+  // Extract fields from YAML with sensible defaults
+  const title = (attributes.title && String(attributes.title).trim())
+    || fileInfo.relativePath.replace(/\.md$/, "").split("/").pop();
+
+  const docType = ["entity", "concept", "source", "synthesis"].includes(attributes.type)
+    ? attributes.type : null;
+
+  const tags = Array.isArray(attributes.tags)
+    ? JSON.stringify(attributes.tags.filter(Boolean))
+    : JSON.stringify([]);
+
+  const connections = Array.isArray(attributes.connections)
+    ? JSON.stringify(attributes.connections.filter(Boolean))
+    : JSON.stringify([]);
+
+  const sources = Array.isArray(attributes.sources)
+    ? JSON.stringify(attributes.sources.filter(Boolean))
+    : JSON.stringify([]);
+
+  const docDate = (attributes.last_updated && typeof attributes.last_updated === "string")
+    ? attributes.last_updated.trim() : null;
+
+  const reviewStatus = ["seed", "developing", "mature"].includes(attributes.status)
+    ? attributes.status : null;
+
+  // Extract category from the first path segment (subdirectory under wiki/)
+  const parts = fileInfo.relativePath.split("/");
+  const category = parts.length > 1 ? parts[0] : null;
+
   const existing = db
     .prepare("SELECT * FROM kb_documents WHERE original_path = ? AND source = ?")
     .get(fileInfo.relativePath, src);
@@ -103,15 +139,13 @@ function importDocument(db, fileInfo, conflictStrategy, now, source) {
       const hash = crypto.createHash("sha256").update(fileInfo.relativePath, "utf8").digest("hex").slice(0, 8);
       slug = slug + "-" + hash;
     }
-    const tags = JSON.stringify([]);
-    const title = fileInfo.relativePath.replace(/\.md$/, "").split("/").pop();
-    const wordCount = fileInfo.content.split(/\s+/).filter(Boolean).length;
+    const wordCount = body.split(/\s+/).filter(Boolean).length;
     const info = db
       .prepare(
-        `INSERT INTO kb_documents (title, slug, content_markdown, source, original_path, checksum, tags, status, word_count, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?)`,
+        `INSERT INTO kb_documents (title, slug, content_markdown, source, original_path, checksum, tags, status, category, doc_type, connections, sources, doc_date, review_status, word_count, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(title, slug, fileInfo.content, src, fileInfo.relativePath, fileInfo.checksum, tags, wordCount, now, now);
+      .run(title, slug, body, src, fileInfo.relativePath, fileInfo.checksum, tags, category, docType, connections, sources, docDate, reviewStatus, wordCount, now, now);
     return { action: "imported", id: info.lastInsertRowid, path: fileInfo.relativePath };
   }
 
@@ -130,23 +164,22 @@ function importDocument(db, fileInfo, conflictStrategy, now, source) {
 
   if (conflictStrategy === "keep_both") {
     const newSlug = existing.slug + "-" + Date.now();
-    const title = existing.title + " (冲突副本)";
-    const wordCount = fileInfo.content.split(/\s+/).filter(Boolean).length;
-    const tags = JSON.stringify([]);
+    const newTitle = existing.title + " (冲突副本)";
+    const wordCount = body.split(/\s+/).filter(Boolean).length;
     const info = db
       .prepare(
-        `INSERT INTO kb_documents (title, slug, content_markdown, source, original_path, checksum, tags, status, word_count, created_at, updated_at)
-       VALUES (?, ?, ?, 'obsidian', ?, ?, ?, 'active', ?, ?, ?)`,
+        `INSERT INTO kb_documents (title, slug, content_markdown, source, original_path, checksum, tags, status, category, doc_type, connections, sources, doc_date, review_status, word_count, created_at, updated_at)
+       VALUES (?, ?, ?, 'obsidian', ?, ?, ?, 'active', ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(title, newSlug, fileInfo.content, fileInfo.relativePath, fileInfo.checksum, tags, wordCount, now, now);
+      .run(newTitle, newSlug, body, fileInfo.relativePath, fileInfo.checksum, tags, category, docType, connections, sources, docDate, reviewStatus, wordCount, now, now);
     return { action: "conflict", id: info.lastInsertRowid, path: fileInfo.relativePath, detail: "created conflict copy" };
   }
 
   // last_write_wins
-  const wordCount = fileInfo.content.split(/\s+/).filter(Boolean).length;
+  const wordCount = body.split(/\s+/).filter(Boolean).length;
   db.prepare(
-    "UPDATE kb_documents SET content_markdown = ?, checksum = ?, content_html = NULL, word_count = ?, updated_at = ? WHERE id = ?",
-  ).run(fileInfo.content, fileInfo.checksum, wordCount, now, existing.id);
+    `UPDATE kb_documents SET title=?, slug=?, content_markdown=?, checksum=?, content_html=NULL, tags=?, category=?, doc_type=?, connections=?, sources=?, doc_date=?, review_status=?, word_count=?, updated_at=? WHERE id=?`,
+  ).run(title, existing.slug, body, fileInfo.checksum, tags, category, docType, connections, sources, docDate, reviewStatus, wordCount, now, existing.id);
   return { action: "updated", id: existing.id, path: fileInfo.relativePath };
 }
 
@@ -226,13 +259,14 @@ async function fullImport(vaultPath, conflictStrategy) {
 }
 
 /**
- * Lightweight scan: only return file paths (no content), for building file trees.
+ * Lightweight scan: only return file paths (no content) from wiki/ subdirectory, for building file trees.
  */
 function scanVaultPaths(vaultPath) {
   const results = [];
-  if (!fs.existsSync(vaultPath)) return results;
+  const wikiPath = path.join(vaultPath, "wiki");
+  if (!fs.existsSync(wikiPath)) return results;
 
-  const resolved = path.resolve(vaultPath);
+  const resolved = path.resolve(wikiPath);
   const normalized = path.normalize(resolved);
 
   function walk(dir) {
@@ -251,14 +285,14 @@ function scanVaultPaths(vaultPath) {
         try { size = fs.statSync(full).size; } catch { /* skip */ }
         if (size > MAX_FILE_SIZE) continue;
         results.push({
-          relativePath: path.relative(vaultPath, full).replace(/\\/g, "/"),
+          relativePath: path.relative(wikiPath, full).replace(/\\/g, "/"),
           size,
           checksum: null, // not computed for tree view
         });
       }
     }
   }
-  walk(vaultPath);
+  walk(wikiPath);
   return results;
 }
 

--- a/server/src/apps/admin/kb/syncHandlers.js
+++ b/server/src/apps/admin/kb/syncHandlers.js
@@ -205,7 +205,17 @@ async function testFilesystem(req, res) {
       return res.json({ code: 200, data: { ok: false, message: "路径不是目录", path: resolved } });
     }
 
-    // Scan for .md files
+    // Only scan the wiki/ subdirectory
+    const wikiPath = require("path").join(resolved, "wiki");
+    if (!fs.existsSync(wikiPath)) {
+      const detail = `路径下未找到 wiki/ 子目录: ${resolved}`;
+      db.prepare(
+        "INSERT INTO kb_sync_logs (direction, file_path, status, detail, created_at) VALUES (?, ?, ?, ?, ?)",
+      ).run("import", vaultPath, "error", detail, now);
+      return res.json({ code: 200, data: { ok: false, message: detail, path: wikiPath } });
+    }
+
+    // Scan for .md files in wiki/
     let mdCount = 0;
     let totalSize = 0;
     function walk(dir, depth) {
@@ -224,7 +234,7 @@ async function testFilesystem(req, res) {
         }
       }
     }
-    walk(resolved, 0);
+    walk(wikiPath, 0);
 
     const detail = `连接成功: 找到 ${mdCount} 个 .md 文件 (${(totalSize / 1024 / 1024).toFixed(1)} MB)`;
     db.prepare(

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -346,6 +346,25 @@ function migrate(db) {
   // Seed the singleton row for kb_sync_config
   db.prepare(`INSERT OR IGNORE INTO kb_sync_config (id, vault_path, created_at, updated_at) VALUES (1, '', datetime('now'), datetime('now'))`).run();
 
+  // Phase 7b: Wiki subdirectory + YAML front matter fields
+  const kbAdds = [
+    `ALTER TABLE kb_documents ADD COLUMN category TEXT DEFAULT NULL`,
+    `ALTER TABLE kb_documents ADD COLUMN doc_type TEXT DEFAULT NULL CHECK (doc_type IN ('entity','concept','source','synthesis'))`,
+    `ALTER TABLE kb_documents ADD COLUMN connections TEXT NOT NULL DEFAULT '[]'`,
+    `ALTER TABLE kb_documents ADD COLUMN sources TEXT NOT NULL DEFAULT '[]'`,
+    `ALTER TABLE kb_documents ADD COLUMN doc_date TEXT DEFAULT NULL`,
+    `ALTER TABLE kb_documents ADD COLUMN review_status TEXT DEFAULT NULL CHECK (review_status IN ('seed','developing','mature'))`,
+  ];
+  for (const sql of kbAdds) {
+    try { db.exec(sql); } catch (e) { /* column already exists */ }
+  }
+  try { db.exec(`CREATE INDEX IF NOT EXISTS idx_kb_docs_category ON kb_documents(category)`); } catch { /* ignore */ }
+
+  // Migrate existing obsidian original_path to strip wiki/ prefix
+  try {
+    db.exec(`UPDATE kb_documents SET original_path = SUBSTR(original_path, 6), checksum = NULL, updated_at = datetime('now') WHERE source = 'obsidian' AND original_path LIKE 'wiki/%'`);
+  } catch { /* ignore */ }
+
 }
 
 function ensureSeed(db) {


### PR DESCRIPTION
## Summary

- 同步引擎改为只扫描仓库下的 `wiki/` 子目录，不再扫描整个仓库
- 新增 YAML 表头解析（`js-yaml`），提取 `title/type/tags/connections/sources/last_updated/status` 作为结构化字段存储
- 正文仅保存表头以外部分，去掉 YAML 元数据
- 按子目录名自动设置 `category`（如 `wiki/notes/xxx.md` → category=notes）
- API 新增 `category` 筛选参数和 `GET /documents/categories` 端点
- 新增 6 个数据库字段：`category`, `doc_type`, `connections`, `sources`, `doc_date`, `review_status`
- 前端列表页支持分类筛选、卡片/表格显示分类；编辑页新增所有 YAML 字段表单

## Test plan

- [ ] 配置同步仓库路径，确保 `wiki/` 子目录存在
- [ ] 触发导入，验证仅 `wiki/` 下文件被导入，标题/类型/标签等来自 YAML 表头
- [ ] 验证正文不含 YAML 表头内容
- [ ] 验证 `?category=notes` 筛选生效
- [ ] 验证前端分类下拉菜单、分类标签显示
- [ ] 手动新建/编辑文档时验证新字段提交和回显
- [ ] 验证无 YAML 表头的旧文档仍可正常显示