### PR TITLE
fix: KB列表筛选/排序增强 + 编辑页YAML字段完整保留

### DIFF
--- a/admin/src/api/kb.ts
+++ b/admin/src/api/kb.ts
@@ -38,7 +38,8 @@ export interface KbDocumentQuery {
   status?: string
   tag?: string
   category?: string
-  sortBy?: 'updated_at' | 'created_at' | 'title' | 'word_count'
+  review_status?: string
+  sortBy?: string
   sortDir?: 'asc' | 'desc'
 }
 

--- a/admin/src/views/kb/documents/edit.vue
+++ b/admin/src/views/kb/documents/edit.vue
@@ -132,13 +132,17 @@ function parseYamlFrontMatter(content: string): { attributes: Record<string, unk
 
 /**
  * Build YAML front matter string from attributes object.
+ * Writes all keys, with known keys ordered first.
  */
 function buildYamlFrontMatter(attrs: Record<string, unknown>): string {
-  const keys = ['title', 'type', 'tags', 'connections', 'sources', 'last_updated', 'status']
+  const knownKeys = ['title', 'type', 'tags', 'connections', 'sources', 'last_updated', 'status']
+  const written = new Set<string>()
   const lines: string[] = []
-  for (const k of keys) {
+
+  for (const k of knownKeys) {
     const v = attrs[k]
     if (v === undefined || v === null || v === '') continue
+    written.add(k)
     if (Array.isArray(v) && v.length === 0) continue
     if (Array.isArray(v)) {
       const items = v.map((i: unknown) => typeof i === 'string' && i.includes(' ') ? `"${i}"` : String(i)).join(', ')
@@ -149,6 +153,21 @@ function buildYamlFrontMatter(attrs: Record<string, unknown>): string {
       lines.push(`${k}: ${v}`)
     }
   }
+
+  // Write extra keys (preserves unknown YAML fields)
+  for (const k of Object.keys(attrs)) {
+    if (written.has(k)) continue
+    const v = attrs[k]
+    if (v === undefined || v === null || v === '') continue
+    if (Array.isArray(v) && v.length === 0) continue
+    if (Array.isArray(v)) {
+      const items = v.map((i: unknown) => typeof i === 'string' && i.includes(' ') ? `"${i}"` : String(i)).join(', ')
+      lines.push(`${k}: [${items}]`)
+    } else {
+      lines.push(`${k}: ${v}`)
+    }
+  }
+
   if (lines.length === 0) return ''
   return `---\n${lines.join('\n')}\n---\n`
 }
@@ -172,6 +191,15 @@ async function loadDocument() {
     form.sources = Array.isArray(yaml.sources) ? yaml.sources as string[] : (detail.sources ?? [])
     form.doc_date = yaml.last_updated as string ?? detail.doc_date ?? ''
     form.review_status = yaml.status as string ?? detail.review_status ?? ''
+
+    // Preserve any extra YAML fields not in the known schema
+    const knownKeys = new Set(['title', 'type', 'tags', 'connections', 'sources', 'last_updated', 'status', 'category'])
+    for (const k of Object.keys(extraYamlFields)) delete extraYamlFields[k]
+    for (const k of Object.keys(yaml)) {
+      if (!knownKeys.has(k)) {
+        extraYamlFields[k] = yaml[k]
+      }
+    }
 
     // Editor shows only body (YAML front matter stripped)
     form.content_markdown = body
@@ -201,7 +229,7 @@ async function doSave(): Promise<boolean> {
   }
   submitting.value = true
   try {
-    // Reconstruct YAML front matter from form fields + body
+    // Reconstruct YAML front matter from form fields + extra fields + body
     const yamlStr = buildYamlFrontMatter({
       title: form.title || undefined,
       type: form.doc_type || undefined,
@@ -210,6 +238,7 @@ async function doSave(): Promise<boolean> {
       sources: form.sources,
       last_updated: form.doc_date || undefined,
       status: form.review_status || undefined,
+      ...extraYamlFields,
     })
     const fullContent = yamlStr + form.content_markdown
 
@@ -292,6 +321,21 @@ onBeforeUnmount(() => {
 
 const headerTitle = computed(() => isEdit.value ? '编辑文档' : '新建文档')
 const headerSubtitle = computed(() => isEdit.value ? `文档 ID #${editingId.value}` : '创建新知识库文档')
+
+// Holds extra YAML fields not part of the known schema, to preserve on save
+const extraYamlFields = reactive<Record<string, unknown>>({})
+const extraYamlEntries = computed<[string, unknown][]>(() => Object.keys(extraYamlFields).map(k => [k, extraYamlFields[k]]))
+const hasExtraFields = computed(() => extraYamlEntries.value.length > 0)
+
+function formatExtraVal(val: unknown): string {
+  return Array.isArray(val) ? (val as string[]).join(', ') : String(val ?? '')
+}
+
+function updateExtraField(key: string, origVal: unknown, newVal: string) {
+  extraYamlFields[key] = Array.isArray(origVal)
+    ? newVal.split(',').map(s => s.trim()).filter(Boolean)
+    : newVal
+}
 </script>
 
 <template>
@@ -399,6 +443,21 @@ const headerSubtitle = computed(() => isEdit.value ? `文档 ID #${editingId.val
           <NFormItem label="正文" path="content_markdown">
             <MarkdownEditor v-model="form.content_markdown" :height="500" />
           </NFormItem>
+
+          <!-- Extra YAML fields (preserved from original front matter) -->
+          <template v-if="hasExtraFields && isEdit">
+            <NFormItem
+              v-for="[key, val] in extraYamlEntries"
+              :key="key"
+              :label="key"
+            >
+              <NInput
+                :value="formatExtraVal(val)"
+                @update:value="updateExtraField(key, val, $event)"
+                :placeholder="key"
+              />
+            </NFormItem>
+          </template>
         </NForm>
       </div>
     </NSpin>

--- a/admin/src/views/kb/documents/index.vue
+++ b/admin/src/views/kb/documents/index.vue
@@ -56,9 +56,13 @@ interface DocQuery {
   source: string
   status: string
   category: string
+  tag: string
+  review_status: string
+  sortBy: string
+  sortDir: string
 }
 
-const initialQuery: DocQuery = { search: '', contentSearch: false, source: '', status: '', category: '' }
+const initialQuery: DocQuery = { search: '', contentSearch: false, source: '', status: '', category: '', tag: '', review_status: '', sortBy: 'updated_at', sortDir: 'desc' }
 
 const table = useTable<KbDocumentListItem, DocQuery>({
   fetch: async (params) => {
@@ -69,12 +73,28 @@ const table = useTable<KbDocumentListItem, DocQuery>({
       contentSearch: params.contentSearch || undefined,
       source: params.source || undefined,
       status: params.status || undefined,
+      category: params.category || undefined,
+      tag: params.tag || undefined,
+      review_status: params.review_status || undefined,
+      sortBy: params.sortBy || undefined,
+      sortDir: (params.sortDir as 'asc' | 'desc') || undefined,
     })
     return { list: res.items, total: res.total }
   },
   initialQuery,
   pageSize: 12,
 })
+
+function handleSortChange(sorter: { columnKey?: string; order?: 'ascend' | 'descend' }) {
+  if (!sorter.columnKey || !sorter.order) {
+    table.query.sortBy = 'updated_at'
+    table.query.sortDir = 'desc'
+  } else {
+    table.query.sortBy = sorter.columnKey
+    table.query.sortDir = sorter.order === 'ascend' ? 'asc' : 'desc'
+  }
+  table.refresh()
+}
 
 const categoryOptions = ref<Array<{ label: string; value: string }>>([])
 
@@ -102,6 +122,13 @@ const STATUS_OPTIONS = [
   { label: '全部状态', value: '' },
   { label: '活跃', value: 'active' },
   { label: '归档', value: 'archived' },
+]
+
+const REVIEW_STATUS_OPTIONS = [
+  { label: '全部成熟度', value: '' },
+  { label: '草稿 (seed)', value: 'seed' },
+  { label: '完善中 (developing)', value: 'developing' },
+  { label: '成熟 (mature)', value: 'mature' },
 ]
 
 function handleCreate() {
@@ -153,13 +180,14 @@ const tableColumns = computed(() => [
   {
     title: '标题',
     key: 'title' as const,
+    sorter: true,
     ellipsis: { tooltip: true },
-    width: 240,
+    width: 200,
   },
   {
     title: '来源',
     key: 'source' as const,
-    width: 90,
+    width: 80,
     render(row: KbDocumentListItem) {
       return h(NTag, { size: 'small', type: sourceTagType(row.source) }, () => sourceLabel(row.source))
     },
@@ -167,29 +195,53 @@ const tableColumns = computed(() => [
   {
     title: '分类',
     key: 'category' as const,
-    width: 100,
+    sorter: true,
+    width: 90,
     render(row: KbDocumentListItem) {
       return row.category ? h(NTag, { size: 'small', type: 'info' }, () => row.category) : ''
     },
   },
   {
+    title: '文档类型',
+    key: 'doc_type' as const,
+    sorter: true,
+    width: 90,
+    render(row: KbDocumentListItem) {
+      return row.doc_type ? h(NTag, { size: 'small', type: 'warning' }, () => row.doc_type) : ''
+    },
+  },
+  {
     title: '标签',
     key: 'tags' as const,
-    width: 160,
+    width: 140,
     render(row: KbDocumentListItem) {
       if (!row.tags?.length) return ''
-      return row.tags.map((t) => t).join(', ')
+      return row.tags.join(', ')
+    },
+  },
+  {
+    title: '成熟度',
+    key: 'review_status' as const,
+    sorter: true,
+    width: 80,
+    render(row: KbDocumentListItem) {
+      if (!row.review_status) return ''
+      const typeMap: Record<string, 'success' | 'warning' | 'info' | 'default'> = { mature: 'success', developing: 'warning', seed: 'info' }
+      const labelMap: Record<string, string> = { mature: '成熟', developing: '完善中', seed: '草稿' }
+      const rs = row.review_status ?? ''
+      return h(NTag, { size: 'small', type: typeMap[rs] || 'default' }, () => labelMap[rs] || rs)
     },
   },
   {
     title: '字数',
     key: 'word_count' as const,
-    width: 70,
+    sorter: true,
+    width: 60,
   },
   {
     title: '状态',
     key: 'status' as const,
-    width: 70,
+    width: 65,
     render(row: KbDocumentListItem) {
       return row.status === 'active'
         ? h(NTag, { size: 'small', type: 'success' }, () => '活跃')
@@ -199,7 +251,8 @@ const tableColumns = computed(() => [
   {
     title: '更新时间',
     key: 'updated_at' as const,
-    width: 160,
+    sorter: true,
+    width: 150,
     render(row: KbDocumentListItem) {
       return formatDateTime(row.updated_at)
     },
@@ -207,7 +260,7 @@ const tableColumns = computed(() => [
   {
     title: '操作',
     key: 'actions' as const,
-    width: 160,
+    width: 140,
     render(row: KbDocumentListItem) {
       return h('div', { class: 'flex items-center gap-1' }, [
         h(
@@ -292,6 +345,19 @@ const tableColumns = computed(() => [
         v-model:value="table.query.category"
         :options="categoryOptions"
         placeholder="分类"
+        clearable
+        style="width: 130px"
+      />
+      <NInput
+        v-model:value="table.query.tag"
+        placeholder="标签筛选"
+        clearable
+        style="width: 120px"
+      />
+      <NSelect
+        v-model:value="table.query.review_status"
+        :options="REVIEW_STATUS_OPTIONS"
+        placeholder="成熟度"
         clearable
         style="width: 130px"
       />
@@ -409,6 +475,7 @@ const tableColumns = computed(() => [
           striped
           size="small"
           class="rounded-xl overflow-hidden"
+          @update:sorter="handleSortChange"
         />
       </template>
     </NSpin>

--- a/server/src/apps/admin/kb/documentHandlers.js
+++ b/server/src/apps/admin/kb/documentHandlers.js
@@ -72,9 +72,10 @@ function listDocuments(req, res) {
   const status = String(req.query.status || "").trim() || null;
   const tag = String(req.query.tag || "").trim() || null;
   const category = String(req.query.category || "").trim() || null;
+  const reviewStatus = String(req.query.review_status || "").trim() || null;
   const sortBy = String(req.query.sortBy || "updated_at");
   const sortDir = String(req.query.sortDir || "desc").toLowerCase() === "asc" ? "ASC" : "DESC";
-  const allowedSorts = new Set(["updated_at", "created_at", "title", "word_count"]);
+  const allowedSorts = new Set(["updated_at", "created_at", "title", "word_count", "category", "doc_type", "review_status"]);
   const orderCol = allowedSorts.has(sortBy) ? sortBy : "updated_at";
 
   const where = ["1=1"];
@@ -107,6 +108,10 @@ function listDocuments(req, res) {
   if (category) {
     where.push("category = ?");
     params.push(category);
+  }
+  if (reviewStatus) {
+    where.push("review_status = ?");
+    params.push(reviewStatus);
   }
 
   const clause = where.join(" AND ");


### PR DESCRIPTION
## Summary

### 1. 分类筛选
修复分类筛选逻辑，确保 category 参数正确传递和过滤。

### 2. 标签筛选
新增标签文本输入筛选，输入标签名即可过滤。

### 3. 成熟度筛选
新增 review_status 下拉筛选（seed / developing / mature）。

### 4. 列排序
列表视图（DataTable）支持点击列头排序，可排序字段：标题、分类、文档类型、成熟度、字数、更新时间。

### 5. YAML 字段完整保留
编辑页解析 YAML 表头时，保留所有不在预定义 schema 中的额外字段。保存时完整重建 YAML，不会丢失数据。额外字段在编辑页底部以可编辑表单显示。

## Test plan
- [ ] 验证分类/标签/成熟度筛选正常
- [ ] 验证表头点击排序正常（升序/降序切换）
- [ ] 验证含额外 YAML 字段的文档编辑后不丢失字段
- [ ] 验证构建通过