### PR TITLE
feat: 平台数据导出到Obsidian仓库

### DIFF
--- a/admin/src/views/kb/sync/index.vue
+++ b/admin/src/views/kb/sync/index.vue
@@ -23,6 +23,7 @@ import {
   apiGetSyncConfig,
   apiUpdateSyncConfig,
   apiTriggerSyncImport,
+  apiTriggerSyncExport,
   apiGetSyncStatus,
   apiListSyncLogs,
   apiTestFilesystem,
@@ -42,6 +43,7 @@ const hasSyncPerm = computed(() => permissionStore.hasPermission('kb:sync'))
 
 const loading = ref(false)
 const syncing = ref(false)
+const exporting = ref(false)
 const clearing = ref(false)
 const saving = ref(false)
 const testingFs = ref(false)
@@ -230,6 +232,21 @@ async function handleSyncNow() {
   }
 }
 
+async function handleSyncExport() {
+  exporting.value = true
+  try {
+    const res = await apiTriggerSyncExport()
+    if ((res as unknown as { status: string }).status) {
+      message.info('导出已启动')
+      startLivePolling()
+    }
+  } catch {
+    message.error('启动导出失败')
+  } finally {
+    exporting.value = false
+  }
+}
+
 async function handleClearData() {
   clearing.value = true
   try {
@@ -400,6 +417,17 @@ onMounted(() => {
             >
               <template #icon><CloudUploadOutline class="w-4 h-4" /></template>
               立即导入
+            </NButton>
+            <NButton
+              size="small"
+              secondary
+              type="warning"
+              :loading="exporting"
+              :disabled="!hasSyncPerm"
+              @click="handleSyncExport"
+            >
+              <template #icon><RefreshOutline class="w-4 h-4" /></template>
+              导出到Obsidian
             </NButton>
             <NButton
               size="small"

--- a/server/src/apps/admin/kb/frontmatter.js
+++ b/server/src/apps/admin/kb/frontmatter.js
@@ -27,4 +27,48 @@ function parseFrontMatter(content) {
   }
 }
 
-module.exports = { parseFrontMatter };
+/**
+ * Build YAML front matter string from attributes object, then append body.
+ * Known keys are ordered first; extra keys follow alphabetically.
+ * @param {Object} attributes
+ * @param {string} body
+ * @returns {string} Full document content with YAML front matter + body
+ */
+function buildFrontMatter(attributes, body) {
+  const knownKeys = ["title", "type", "tags", "connections", "sources", "last_updated", "status"];
+  const written = new Set();
+  const lines = [];
+
+  for (const k of knownKeys) {
+    const v = attributes[k];
+    if (v === undefined || v === null || v === "") continue;
+    written.add(k);
+    if (Array.isArray(v)) {
+      if (v.length === 0) continue;
+      const items = v.map(i => String(i).includes(" ") ? `"${i}"` : String(i)).join(", ");
+      lines.push(`${k}: [${items}]`);
+    } else if (typeof v === "string" && /[:\-\[\]]/.test(v)) {
+      lines.push(`${k}: "${v}"`);
+    } else {
+      lines.push(`${k}: ${v}`);
+    }
+  }
+
+  // Extra keys (not in known set)
+  for (const k of Object.keys(attributes).sort()) {
+    if (written.has(k)) continue;
+    const v = attributes[k];
+    if (v === undefined || v === null || v === "") continue;
+    if (Array.isArray(v)) {
+      if (v.length === 0) continue;
+      lines.push(`${k}: [${v.join(", ")}]`);
+    } else {
+      lines.push(`${k}: ${v}`);
+    }
+  }
+
+  if (lines.length === 0) return body || "";
+  return `---\n${lines.join("\n")}\n---\n${body || ""}`;
+}
+
+module.exports = { parseFrontMatter, buildFrontMatter };

--- a/server/src/apps/admin/kb/syncEngine.js
+++ b/server/src/apps/admin/kb/syncEngine.js
@@ -3,7 +3,7 @@ const path = require("path");
 const crypto = require("crypto");
 const { openDb } = require("../../../db");
 const { normalizeSlug } = require("../../../utils");
-const { parseFrontMatter } = require("./frontmatter");
+const { parseFrontMatter, buildFrontMatter } = require("./frontmatter");
 
 let _syncing = false;
 
@@ -348,4 +348,93 @@ function buildFileTree(files) {
   return root;
 }
 
-module.exports = { scanVault, scanVaultPaths, buildFileTree, importDocument, fullImport, importFromFiles, computeChecksum, acquireLock, releaseLock, isRunning, MAX_FILE_SIZE };
+function parseTags(raw) {
+  if (!raw) return [];
+  try { return JSON.parse(raw); } catch { return []; }
+}
+
+/**
+ * Full export: write all obsidian-sourced documents back to the vault as .md files.
+ * Builds YAML front matter from DB fields + body from content_markdown.
+ */
+async function fullExport(vaultPath) {
+  if (!acquireLock()) throw new Error("同步正在进行中，请稍后重试");
+  const db = openDb();
+  const now = new Date().toISOString();
+  const wikiPath = path.join(vaultPath, "wiki");
+
+  const logStmt = db.prepare(
+    `INSERT INTO kb_sync_logs (direction, file_path, document_id, status, checksum, detail, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  );
+
+  const summary = { exported: 0, skipped: 0, errors: 0 };
+
+  try {
+    // Ensure wiki/ directory exists
+    fs.mkdirSync(wikiPath, { recursive: true });
+
+    const docs = db
+      .prepare("SELECT * FROM kb_documents WHERE source = 'obsidian'")
+      .all();
+
+    for (const doc of docs) {
+      const targetPath = doc.original_path;
+      if (!targetPath) {
+        summary.errors++;
+        logStmt.run("export", `doc-${doc.id}`, doc.id, "error", null, "missing original_path", now);
+        continue;
+      }
+
+      try {
+        // Build YAML front matter from DB fields
+        const lastUpdated = doc.doc_date || doc.updated_at ? doc.updated_at.slice(0, 10) : null;
+        const yamlAttrs = {
+          title: doc.title || undefined,
+          type: doc.doc_type || undefined,
+          tags: parseTags(doc.tags),
+          connections: parseTags(doc.connections),
+          sources: parseTags(doc.sources),
+          last_updated: lastUpdated,
+          status: doc.review_status || undefined,
+        };
+
+        const body = doc.content_markdown || "";
+        const fullContent = buildFrontMatter(yamlAttrs, body);
+        const checksum = computeChecksum(fullContent);
+
+        // Write file
+        const fullPath = path.join(wikiPath, targetPath);
+        fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+        fs.writeFileSync(fullPath, fullContent, "utf8");
+
+        // Update checksum in DB
+        db.prepare("UPDATE kb_documents SET checksum = ?, updated_at = ? WHERE id = ?")
+          .run(checksum, now, doc.id);
+
+        summary.exported++;
+        logStmt.run("export", targetPath, doc.id, "success", checksum, null, now);
+      } catch (err) {
+        summary.errors++;
+        logStmt.run("export", targetPath, doc.id, "error", null, err.message, now);
+      }
+    }
+
+    db.prepare("UPDATE kb_sync_config SET last_sync_at = ?, updated_at = ? WHERE id = 1").run(now, now);
+    try { db.pragma("wal_checkpoint(PASSIVE)"); } catch { /* ignore */ }
+
+    return summary;
+  } catch (err) {
+    console.error("[kb-sync] fullExport error:", err.message);
+    try {
+      db.prepare(
+        "INSERT INTO kb_sync_logs (direction, file_path, status, detail, created_at) VALUES (?, ?, ?, ?, ?)",
+      ).run("export", vaultPath, "error", `导出异常: ${err.message}`, now);
+    } catch { /* ignore */ }
+    return { exported: 0, skipped: 0, errors: 1 };
+  } finally {
+    releaseLock();
+  }
+}
+
+module.exports = { scanVault, scanVaultPaths, buildFileTree, importDocument, fullImport, importFromFiles, fullExport, computeChecksum, acquireLock, releaseLock, isRunning, MAX_FILE_SIZE };

--- a/server/src/apps/admin/kb/syncHandlers.js
+++ b/server/src/apps/admin/kb/syncHandlers.js
@@ -111,9 +111,38 @@ async function triggerImport(req, res) {
   }
 }
 
-function triggerExport(req, res) {
-  // Export is a placeholder for now
-  res.status(501).json({ code: 501, message: "导出功能尚未实现" });
+async function triggerExport(req, res) {
+  const db = openDb();
+  const config = db.prepare("SELECT * FROM kb_sync_config WHERE id = 1").get();
+  if (!config || !config.vault_path) {
+    return res.status(400).json({ code: 400, message: "请先配置仓库路径 (vault_path)" });
+  }
+
+  if (syncEngine.isRunning()) {
+    return res.status(409).json({ code: 409, message: "同步正在进行中" });
+  }
+
+  // Validate wiki/ exists
+  const wikiPath = require("path").join(config.vault_path, "wiki");
+  if (!require("fs").existsSync(wikiPath)) {
+    return res.status(400).json({ code: 400, message: "仓库路径下未找到 wiki/ 子目录，请先创建或导入数据" });
+  }
+
+  auditLog(db, req, "trigger_export", config.vault_path, "触发平台→Obsidian导出");
+  res.status(202).json({ code: 202, message: "导出已启动" });
+
+  try {
+    await syncEngine.fullExport(config.vault_path);
+  } catch (err) {
+    console.error("[kb-sync] export failed:", err.message);
+    try {
+      const db2 = openDb();
+      const now2 = nowIso();
+      db2.prepare(
+        "INSERT INTO kb_sync_logs (direction, file_path, status, detail, created_at) VALUES (?, ?, ?, ?, ?)",
+      ).run("export", config.vault_path, "error", `导出失败: ${err.message}`, now2);
+    } catch { /* ignore */ }
+  }
 }
 
 function listSyncLogs(req, res) {


### PR DESCRIPTION
## Summary

将 KB 中 source='obsidian' 的文档写回 Obsidian 仓库的 wiki/ 子目录，实现双向同步。

### 后端
- `frontmatter.js`: 新增 `buildFrontMatter(attributes, body)` 从属性和正文重建完整 .md 内容
- `syncEngine.js`: 新增 `fullExport(vaultPath)` — 遍历所有 obsidian 源文档，重建 YAML 表头 + 正文写入文件系统，记录同步日志
- `syncHandlers.js`: `triggerExport` 从 501 占位改为实际实现

### 前端
- 同步页面新增"导出到Obsidian"按钮，调用导出接口并启动实时日志轮询

## Test plan
- [ ] 配置仓库路径，确认 wiki/ 子目录存在且有已同步文档
- [ ] 点击"导出到Obsidian"，验证文件写入 wiki/ 对应路径
- [ ] 验证导出的 .md 文件包含完整的 YAML 表头
- [ ] 验证实时日志显示导出进度
- [ ] 验证无文档时导出不报错