### PR TITLE
fix: 导入导出报错和日志展示问题

### DIFF
--- a/admin/src/views/kb/sync/index.vue
+++ b/admin/src/views/kb/sync/index.vue
@@ -98,9 +98,7 @@ function startLivePolling() {
       const s = await apiGetSyncStatus()
       status.value = s
       const res = await apiListSyncLogs({ page: 1, pageSize: 200, since })
-      const fresh = res.items
-        .filter((l) => l.direction === 'import')
-        .reverse()
+      const fresh = res.items.reverse()
       if (fresh.length > liveLogs.value.length) {
         liveLogs.value = fresh
         autoScrollLive()

--- a/server/src/apps/admin/kb/syncEngine.js
+++ b/server/src/apps/admin/kb/syncEngine.js
@@ -403,6 +403,13 @@ async function fullExport(vaultPath) {
         const fullContent = buildFrontMatter(yamlAttrs, body);
         const checksum = computeChecksum(fullContent);
 
+        // Skip if content hasn't changed since last export/import
+        if (doc.checksum === checksum) {
+          summary.skipped++;
+          logStmt.run("export", targetPath, doc.id, "skipped", checksum, "no changes", now);
+          continue;
+        }
+
         // Write file
         const fullPath = path.join(wikiPath, targetPath);
         fs.mkdirSync(path.dirname(fullPath), { recursive: true });

--- a/server/src/apps/admin/kb/syncHandlers.js
+++ b/server/src/apps/admin/kb/syncHandlers.js
@@ -95,7 +95,7 @@ async function triggerImport(req, res) {
 
   // Respond immediately, run sync async
   auditLog(db, req, "trigger_import", config.vault_path, "触发文件系统同步");
-  res.status(202).json({ code: 202, message: "同步已启动 (文件系统)" });
+  res.status(202).json({ code: 202, message: "同步已启动 (文件系统)", data: { status: "started" } });
 
   try {
     await syncEngine.fullImport(config.vault_path, config.conflict_strategy || "last_write_wins");
@@ -129,7 +129,7 @@ async function triggerExport(req, res) {
   }
 
   auditLog(db, req, "trigger_export", config.vault_path, "触发平台→Obsidian导出");
-  res.status(202).json({ code: 202, message: "导出已启动" });
+  res.status(202).json({ code: 202, message: "导出已启动", data: { status: "started" } });
 
   try {
     await syncEngine.fullExport(config.vault_path);
@@ -182,15 +182,13 @@ function getSyncStatus(_req, res) {
   let lastResult = null;
   if (config && config.last_sync_at) {
     const logs = db
-      .prepare("SELECT status, COUNT(*) AS c FROM kb_sync_logs WHERE direction = 'import' AND created_at = ? GROUP BY status")
+      .prepare("SELECT direction, status, COUNT(*) AS c FROM kb_sync_logs WHERE created_at = ? GROUP BY direction, status")
       .all(config.last_sync_at);
     if (logs.length > 0) {
-      lastResult = { imported: 0, skipped: 0, conflicted: 0, errors: 0 };
+      lastResult = { imported: 0, skipped: 0, conflicted: 0, errors: 0, exported: 0 };
       for (const row of logs) {
-        if (row.status === "success") lastResult.imported += row.c;
-        else if (row.status === "skipped") lastResult.skipped += row.c;
-        else if (row.status === "conflict") lastResult.conflicted += row.c;
-        else if (row.status === "error") lastResult.errors += row.c;
+        const key = row.direction === "export" ? "exported" : row.status === "success" ? "imported" : row.status;
+        if (lastResult[key] !== undefined) lastResult[key] += row.c;
       }
     }
   }


### PR DESCRIPTION
## 修复

1. **前端报错 "启动同步失败"**：`triggerImport` 和 `triggerExport` 的 202 响应缺少 `data` 字段，`apiTriggerSyncImport()` 返回 `undefined`，前端访问 `.status` 时抛 TypeError 触发 catch。

2. **实时日志只显示导入**：live polling 过滤了 `direction === 'import'`，改为双向都显示。

3. **同步状态只统计导入**：`getSyncStatus` 的 SQL 加了 `direction = 'import'` 过滤，改为按 direction+status 分组，结果新增 `exported` 计数。

4. **导出未跳过不变文件**：`fullExport` 新增 checksum 比对跳过未变更文档。

## Test plan
- [ ] 点击 "立即导入" 不再弹出 "启动同步失败"
- [ ] 实时日志同时显示导入和导出记录
- [ ] 导入数据后导出，导出日志显示成功/跳过