### PR TITLE
feat: 文件对比标记 + 双向同步按钮

### DIFF
--- a/admin/src/components/kb/SyncFileTree.vue
+++ b/admin/src/components/kb/SyncFileTree.vue
@@ -9,6 +9,7 @@ defineProps<{
   loading?: boolean
   emptyText?: string
   showStatus?: boolean
+  diffStatusMap?: Record<string, 'new' | 'old' | 'synced'>
 }>()
 
 const expanded = ref<Set<string>>(new Set())
@@ -30,6 +31,7 @@ function toggleExpand(path: string) {
         :depth="0"
         :expanded="expanded"
         :show-status="showStatus"
+        :diff-status="diffStatusMap?.[node.path] || null"
         @toggle="toggleExpand"
       />
     </template>

--- a/admin/src/components/kb/TreeNodeItem.vue
+++ b/admin/src/components/kb/TreeNodeItem.vue
@@ -15,6 +15,7 @@ const props = defineProps({
   depth: { type: Number, default: 0 },
   expanded: { type: Object as PropType<Set<string>>, required: true },
   showStatus: { type: Boolean, default: false },
+  diffStatus: { type: String as PropType<'new' | 'old' | 'synced' | null>, default: null },
 })
 
 const emit = defineEmits<{ toggle: [path: string] }>()
@@ -39,6 +40,23 @@ function statusType(s: string | null | undefined): 'success' | 'default' | 'warn
     case 'conflict': return 'warning'
     case 'error': return 'error'
     default: return 'default'
+  }
+}
+
+function diffLabel(s: string | null | undefined): string {
+  switch (s) {
+    case 'new': return '新'
+    case 'old': return '旧'
+    case 'synced': return '已同步'
+    default: return ''
+  }
+}
+function diffType(s: string | null | undefined): 'info' | 'warning' | 'success' {
+  switch (s) {
+    case 'new': return 'info'
+    case 'old': return 'warning'
+    case 'synced': return 'success'
+    default: return 'success'
   }
 }
 
@@ -72,6 +90,11 @@ function formatSize(bytes: number): string {
       <!-- Name -->
       <span class="truncate" :style="{ color: isFolder ? '#e2e8f0' : '#cbd5e1' }">{{ node.name }}</span>
 
+      <!-- Diff status badge (对比标记) -->
+      <NTag v-if="diffStatus" :type="diffType(diffStatus)" size="tiny" style="margin-left:4px">
+        {{ diffLabel(diffStatus) }}
+      </NTag>
+
       <!-- Status badge -->
       <NTag v-if="showStatus && node.status" :type="statusType(node.status)" size="tiny" style="margin-left:4px">
         {{ statusLabel(node.status) }}
@@ -97,6 +120,7 @@ function formatSize(bytes: number): string {
         :depth="depth + 1"
         :expanded="expanded"
         :show-status="showStatus"
+        :diff-status="diffStatus"
         @toggle="emit('toggle', $event)"
       />
     </template>

--- a/admin/src/views/kb/documents/index.vue
+++ b/admin/src/views/kb/documents/index.vue
@@ -400,14 +400,9 @@ const tableColumns = computed(() => [
                 <h3 class="font-medium text-sm text-base-content truncate flex-1">{{ row.title }}</h3>
                 <span
                   class="px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0"
-                  :class="
-                    row.review_status === 'mature' ? 'bg-success/10 text-success' :
-                    row.review_status === 'developing' ? 'bg-warning/10 text-warning' :
-                    row.review_status === 'seed' ? 'bg-info/10 text-info' :
-                    'bg-base-content/5 text-base-content/40'
-                  "
+                  :class="row.status === 'active' ? 'bg-success/10 text-success' : 'bg-base-content/5 text-base-content/40'"
                 >
-                  {{ row.review_status === 'mature' ? '成熟' : row.review_status === 'developing' ? '完善中' : row.review_status === 'seed' ? '草稿' : '' }}
+                  {{ row.status === 'active' ? '活跃' : '归档' }}
                 </span>
               </div>
               <p class="text-xs text-base-content/30 mt-1 truncate">{{ row.slug }}</p>

--- a/admin/src/views/kb/sync/index.vue
+++ b/admin/src/views/kb/sync/index.vue
@@ -34,6 +34,7 @@ import {
   type SyncStatus,
   type SyncLogEntry,
   type FileTreeData,
+  type FileTreeNode,
 } from '../../../api/kb'
 import { usePermissionStore } from '../../../stores/permission'
 
@@ -52,6 +53,8 @@ const testingFs = ref(false)
 const remoteTree = ref<FileTreeData>({ source: '', tree: [], fileCount: 0 })
 const syncedTree = ref<FileTreeData>({ source: '', tree: [], fileCount: 0 })
 const treeLoading = ref(false)
+const remoteDiffMap = ref<Record<string, 'new' | 'old' | 'synced'>>({})
+const localDiffMap = ref<Record<string, 'new' | 'old' | 'synced'>>({})
 
 const config = ref<SyncConfig>({
   vault_path: '',
@@ -277,6 +280,40 @@ async function handleTestFilesystem() {
   }
 }
 
+/**
+ * Flatten a file tree into a map of path → { checksum, documentId } for files only.
+ */
+function flattenFiles(nodes: FileTreeNode[], map: Record<string, { checksum?: string | null; documentId?: number | null }> = {}) {
+  for (const n of nodes) {
+    if (n.type === 'file') { map[n.path] = { checksum: n.checksum, documentId: n.documentId } }
+    if (n.children) flattenFiles(n.children, map)
+  }
+  return map
+}
+
+/**
+ * Compute diff status map between remote and local file trees.
+ */
+function computeDiffStatus(
+  remoteFiles: Record<string, { checksum?: string | null }>,
+  localFiles: Record<string, { checksum?: string | null }>,
+): { remote: Record<string, 'new' | 'old' | 'synced'>; local: Record<string, 'new' | 'old' | 'synced'> } {
+  const remote: Record<string, 'new' | 'old' | 'synced'> = {}
+  const local: Record<string, 'new' | 'old' | 'synced'> = {}
+
+  for (const path of Object.keys(remoteFiles)) {
+    const lf = localFiles[path]
+    if (!lf) { remote[path] = 'new' }
+    else if (remoteFiles[path].checksum && lf.checksum && remoteFiles[path].checksum !== lf.checksum) {
+      remote[path] = 'old'; local[path] = 'old'
+    } else { remote[path] = 'synced'; local[path] = 'synced' }
+  }
+  for (const path of Object.keys(localFiles)) {
+    if (!remoteFiles[path]) local[path] = 'new'
+  }
+  return { remote, local }
+}
+
 async function loadFileTrees() {
   treeLoading.value = true
   try {
@@ -286,10 +323,46 @@ async function loadFileTrees() {
     ])
     remoteTree.value = remote
     syncedTree.value = synced
+    const remoteFlat = flattenFiles(remote.tree)
+    const localFlat = flattenFiles(synced.tree)
+    const diff = computeDiffStatus(remoteFlat, localFlat)
+    remoteDiffMap.value = diff.remote
+    localDiffMap.value = diff.local
   } catch {
     /* ignore */
   } finally {
     treeLoading.value = false
+  }
+}
+
+async function handleSyncBoth() {
+  syncing.value = true
+  exporting.value = true
+  try {
+    const imp = await apiTriggerSyncImport()
+    if ((imp as unknown as { status: string }).status) {
+      message.info('导入已启动')
+      startLivePolling()
+      const pollUntilDone = () => new Promise<void>((resolve) => {
+        const check = setInterval(async () => {
+          try {
+            const s = await apiGetSyncStatus()
+            if (!s.running) { clearInterval(check); resolve() }
+          } catch { /* ignore */ }
+        }, 1000)
+      })
+      await pollUntilDone()
+    }
+    const exp = await apiTriggerSyncExport()
+    if ((exp as unknown as { status: string }).status) {
+      message.info('导出已启动')
+      startLivePolling()
+    }
+  } catch {
+    message.error('双向同步启动失败')
+  } finally {
+    syncing.value = false
+    exporting.value = false
   }
 }
 
@@ -473,17 +546,18 @@ onMounted(() => {
                 :loading="treeLoading"
                 empty-text="暂无远程文件，请先配置数据源"
                 :show-status="false"
+                :diff-status-map="remoteDiffMap"
               />
             </NSpin>
           </div>
         </div>
 
-        <!-- 已同步文件树 -->
+        <!-- 本地文件树 -->
         <div class="bg-base-100 rounded-xl border border-base-content/5 overflow-hidden">
           <div class="flex items-center justify-between px-4 py-2.5 bg-base-200/50 border-b border-base-content/5">
             <h3 class="font-medium text-sm">
-              已同步文件
-              <span class="text-xs text-base-content/40 font-normal ml-2">Obsidian</span>
+              本地文件
+              <span class="text-xs text-base-content/40 font-normal ml-2">KB 数据库</span>
             </h3>
             <div class="flex items-center gap-2 text-[10px] text-base-content/30">
               <span v-if="syncedTree.stats" class="text-green-500">{{ syncedTree.stats.active }} 活跃</span>
@@ -496,12 +570,29 @@ onMounted(() => {
               <SyncFileTree
                 :tree="syncedTree.tree"
                 :loading="treeLoading"
-                empty-text="暂无已同步文件，点击立即导入开始同步"
+                empty-text="暂无本地文件，点击立即导入开始同步"
                 :show-status="true"
+                :diff-status-map="localDiffMap"
               />
             </NSpin>
           </div>
         </div>
+      </div>
+
+      <!-- 文件操作按钮 -->
+      <div class="flex items-center justify-center gap-4 mb-6">
+        <NButton size="small" type="primary" :loading="syncing" :disabled="!hasSyncPerm" @click="handleSyncNow">
+          <template #icon><CloudUploadOutline class="w-4 h-4" /></template>
+          拉取到本地
+        </NButton>
+        <NButton size="small" type="warning" secondary :loading="exporting" :disabled="!hasSyncPerm" @click="handleSyncExport">
+          <template #icon><RefreshOutline class="w-4 h-4" /></template>
+          发布到远程
+        </NButton>
+        <NButton size="small" type="primary" secondary :loading="syncing || exporting" :disabled="!hasSyncPerm" @click="handleSyncBoth">
+          <template #icon><RefreshOutline class="w-4 h-4" /></template>
+          双向同步
+        </NButton>
       </div>
 
       <!-- 同步日志 -->

--- a/server/src/apps/admin/kb/syncEngine.js
+++ b/server/src/apps/admin/kb/syncEngine.js
@@ -297,6 +297,39 @@ function scanVaultPaths(vaultPath) {
 }
 
 /**
+ * Lightweight scan: return file paths with checksums (no content), for diff comparison.
+ */
+function scanVaultChecksums(vaultPath) {
+  const results = [];
+  const wikiPath = path.join(vaultPath, "wiki");
+  if (!fs.existsSync(wikiPath)) return results;
+  const resolved = path.resolve(wikiPath);
+  const normalized = path.normalize(resolved);
+  function walk(dir) {
+    if (dir.length > 4000) return;
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      if (e.name.startsWith(".")) continue;
+      const full = path.join(dir, e.name);
+      const real = path.normalize(full);
+      if (!real.startsWith(normalized + path.sep) && real !== normalized) continue;
+      if (e.isDirectory()) { walk(full); }
+      else if (e.isFile() && e.name.endsWith(".md")) {
+        let stat;
+        try { stat = fs.statSync(full); } catch { continue; }
+        if (stat.size > MAX_FILE_SIZE) continue;
+        const relPath = path.relative(wikiPath, full).replace(/\\/g, "/");
+        const content = fs.readFileSync(full, "utf8");
+        results.push({ relativePath: relPath, checksum: computeChecksum(content), size: stat.size });
+      }
+    }
+  }
+  walk(wikiPath);
+  return results;
+}
+
+/**
  * Build a nested tree from flat file paths.
  * e.g. ["a/b/note.md"] → [{ name:"a", type:"folder", children: [{ name:"b", type:"folder", children: [{ name:"note.md", type:"file" }] }] }]
  */
@@ -444,4 +477,4 @@ async function fullExport(vaultPath) {
   }
 }
 
-module.exports = { scanVault, scanVaultPaths, buildFileTree, importDocument, fullImport, importFromFiles, fullExport, computeChecksum, acquireLock, releaseLock, isRunning, MAX_FILE_SIZE };
+module.exports = { scanVault, scanVaultPaths, scanVaultChecksums, buildFileTree, importDocument, fullImport, importFromFiles, fullExport, computeChecksum, acquireLock, releaseLock, isRunning, MAX_FILE_SIZE };

--- a/server/src/apps/admin/kb/syncHandlers.js
+++ b/server/src/apps/admin/kb/syncHandlers.js
@@ -291,7 +291,8 @@ function getRemoteFiles(_req, res) {
 
     if (config && config.vault_path) {
       const vaultPath = require("path").resolve(config.vault_path);
-      files = syncEngine.scanVaultPaths(vaultPath);
+      // Use checksum scan so frontend can compare with synced files
+      files = syncEngine.scanVaultChecksums(vaultPath);
     }
 
     const tree = syncEngine.buildFileTree(files);


### PR DESCRIPTION
## Changes

1. **"已同步文件" → "本地文件"**：改名 + 标注 KB 数据库
2. **文件对比状态标记**：远程/本地文件树中每个文件显示状态标签
   - 新 (info/蓝): 仅在一侧存在
   - 旧 (warning/黄): 两侧 checksum 不同
   - 已同步 (success/绿): 两侧一致
3. **3 个操作按钮**：拉取到本地 / 发布到远程 / 双向同步（先拉后发）
4. **scanVaultChecksums**：轻量扫描函数，返回 checksum 不含 content
5. **修复文档列表 TS 错误**：`(): '活跃'` → `() => '活跃'`