### PR TITLE
feat(charts): add entrance animation to line and bar charts

### DIFF
--- a/admin/src/components/charts/BarChart.vue
+++ b/admin/src/components/charts/BarChart.vue
@@ -59,7 +59,7 @@ function updateOption() {
     title: props.title
       ? { text: props.title, left: 'center', textStyle: { fontSize: 14 } }
       : undefined,
-    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' }, confine: true },
     grid: { left: '3%', right: '4%', bottom: '3%', containLabel: true },
     xAxis: { type: 'value' },
     yAxis: {
@@ -67,6 +67,9 @@ function updateOption() {
       data: reversed.map((item) => item.name),
       axisLabel: { width: 120, overflow: 'truncate' },
     },
+    animation: true,
+    animationDuration: 1200,
+    animationEasing: 'cubicOut',
     series: [
       {
         name: '数量',

--- a/admin/src/components/charts/LineChart.vue
+++ b/admin/src/components/charts/LineChart.vue
@@ -34,11 +34,14 @@ function updateOption() {
     title: props.title
       ? { text: props.title, left: 'center', textStyle: { fontSize: 14 } }
       : undefined,
-    tooltip: { trigger: 'axis' },
+    tooltip: { trigger: 'axis', confine: true },
     legend: { data: props.series.map((s) => s.name), bottom: 0 },
     grid: { left: '3%', right: '4%', bottom: '10%', containLabel: true },
     xAxis: { type: 'category', data: props.labels },
     yAxis: { type: 'value' },
+    animation: true,
+    animationDuration: 1200,
+    animationEasing: 'cubicOut',
     series: props.series.map((s) => {
       const base: any = {
         name: s.name,


### PR DESCRIPTION
Add animation, animationDuration (1200ms), and animationEasing (cubicOut) to LineChart and BarChart components. Confine tooltips to chart area.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)