### PR TITLE
feat(dashboard): restore hourly chart, improve Row 3 layout

### DIFF
--- a/admin/src/views/dashboard/index.vue
+++ b/admin/src/views/dashboard/index.vue
@@ -424,7 +424,7 @@ const dayOptions = [
     </div>
 
     <!-- Charts Row 3 -->
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-5 mb-5">
+    <div class="grid grid-cols-1 lg:grid-cols-4 gap-5 mb-5">
       <div class="base-container p-5">
         <div class="mb-4">
           <h3 class="text-sm font-semibold text-base-content">访问来源 Top 10</h3>
@@ -433,6 +433,13 @@ const dayOptions = [
         <BarChart :items="referrers" :height="260" color="#30d158" />
       </div>
       <div class="base-container p-5">
+        <div class="mb-4">
+          <h3 class="text-sm font-semibold text-base-content">今日时段分布</h3>
+          <p class="text-xs text-base-content/40 mt-0.5">24 小时 PV 分布</p>
+        </div>
+        <LineChart :labels="hourlyLabels" :series="hourlySeries" :height="260" :fill="false" />
+      </div>
+      <div class="lg:col-span-2 base-container p-5">
         <div class="mb-4">
           <h3 class="text-sm font-semibold text-base-content">新增文章</h3>
           <p class="text-xs text-base-content/40 mt-0.5">最近 20 篇文章</p>


### PR DESCRIPTION
## Summary\n- Restore "今日时段分布" (24h PV line chart) in Row 3\n- Row 3 layout: 4-column grid — Referrers (1) | Hourly (1) | Recent Posts (2 cols)\n- Remove duplicate recent posts section\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)