### PR TITLE
feat(dashboard): swap chart positions and add UV to hourly chart

### DIFF
--- a/admin/src/views/dashboard/index.vue
+++ b/admin/src/views/dashboard/index.vue
@@ -83,6 +83,7 @@ async function loadAll() {
     hourlyLabels.value = hourly.labels
     hourlySeries.value = [
       { name: 'PV', data: hourly.pv, color: '#64d2ff' },
+      { name: 'UV', data: hourly.uv, color: '#a78bfa' },
     ]
   } catch (e) {
     console.error('Dashboard load failed:', e)
@@ -427,20 +428,6 @@ const dayOptions = [
     <div class="grid grid-cols-1 lg:grid-cols-4 gap-5 mb-5">
       <div class="base-container p-5">
         <div class="mb-4">
-          <h3 class="text-sm font-semibold text-base-content">访问来源 Top 10</h3>
-          <p class="text-xs text-base-content/40 mt-0.5">Referrer 域名统计</p>
-        </div>
-        <BarChart :items="referrers" :height="260" color="#30d158" />
-      </div>
-      <div class="base-container p-5">
-        <div class="mb-4">
-          <h3 class="text-sm font-semibold text-base-content">今日时段分布</h3>
-          <p class="text-xs text-base-content/40 mt-0.5">24 小时 PV 分布</p>
-        </div>
-        <LineChart :labels="hourlyLabels" :series="hourlySeries" :height="260" :fill="false" />
-      </div>
-      <div class="lg:col-span-2 base-container p-5">
-        <div class="mb-4">
           <h3 class="text-sm font-semibold text-base-content">新增文章</h3>
           <p class="text-xs text-base-content/40 mt-0.5">最近 20 篇文章</p>
         </div>
@@ -462,6 +449,20 @@ const dayOptions = [
             <span class="text-xs text-base-content/40 shrink-0">{{ new Date(post.createdAt).toLocaleDateString('zh-CN') }}</span>
           </div>
         </div>
+      </div>
+      <div class="base-container p-5">
+        <div class="mb-4">
+          <h3 class="text-sm font-semibold text-base-content">访问来源 Top 10</h3>
+          <p class="text-xs text-base-content/40 mt-0.5">Referrer 域名统计</p>
+        </div>
+        <BarChart :items="referrers" :height="260" color="#30d158" />
+      </div>
+      <div class="lg:col-span-2 base-container p-5">
+        <div class="mb-4">
+          <h3 class="text-sm font-semibold text-base-content">今日时段分布</h3>
+          <p class="text-xs text-base-content/40 mt-0.5">24 小时 PV / UV 分布</p>
+        </div>
+        <LineChart :labels="hourlyLabels" :series="hourlySeries" :height="260" :fill="true" />
       </div>
     </div>
 

--- a/server/src/apps/admin/analytics/analyticsRouter.js
+++ b/server/src/apps/admin/analytics/analyticsRouter.js
@@ -207,7 +207,7 @@ router.get("/referrers", (req, res) => {
 
 /**
  * GET /api/v2/admin/analytics/hourly
- * 返回今天 24 小时 PV 分布
+ * 返回今天 24 小时 PV / UV 分布
  */
 router.get("/hourly", (req, res) => {
   const db = openDb();
@@ -217,20 +217,27 @@ router.get("/hourly", (req, res) => {
 
   const labels = [];
   const pv = [];
+  const uv = [];
 
   for (let h = 0; h < 24; h++) {
     const hourStart = `${today}T${String(h).padStart(2, '0')}:00:00.000Z`;
     const hourEnd = `${today}T${String(h).padStart(2, '0')}:59:59.999Z`;
-    const count = db.prepare(`SELECT COUNT(*) as c FROM page_views WHERE created_at >= ? AND created_at < ?`)
-      .get(hourStart, hourEnd)?.c || 0;
+    const row = db.prepare(`
+      SELECT
+        COUNT(*) as pv,
+        COUNT(DISTINCT session_id) as uv
+      FROM page_views
+      WHERE created_at >= ? AND created_at < ?
+    `).get(hourStart, hourEnd);
     labels.push(`${String(h).padStart(2, '0')}:00`);
-    pv.push(count);
+    pv.push(row?.pv || 0);
+    uv.push(row?.uv || 0);
   }
 
   res.json({
     code: 200,
     message: "success",
-    data: { labels, pv },
+    data: { labels, pv, uv },
   });
 });
 


### PR DESCRIPTION
## Summary
- Swap chart positions in Row 3: 新增文章 now first, 访问来源 Top 10 second
- Add UV data series (purple) alongside PV (cyan) in hourly LineChart
- Enable gradient fill on hourly chart
- Update backend hourly endpoint to return UV via `COUNT(DISTINCT session_id)`

## Test plan
- [x] TypeScript check passes (`npx vue-tsc --noEmit`)
- [x] Verify Row 3 layout: 新增文章 → 访问来源 → 今日时段分布
- [x] Verify hourly chart shows both PV (blue) and UV (purple) lines
- [x] CI build completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)