### PR TITLE
feat(iot): add IoT card management module

### DIFF
--- a/admin/src/api/iot.ts
+++ b/admin/src/api/iot.ts
@@ -1,0 +1,97 @@
+// IoT Card Management API client
+import { request, type ApiResponse } from './request'
+import type { AxiosInstance } from 'axios'
+
+export interface CardItem {
+  cardNo: string
+  msisdn: string
+  imsi: string
+  iccid: string
+  operator: string
+  cardType: string
+  comboName: string
+  comboResidue: number
+  comboUsed: number
+  comboTotal: number
+  status: string
+  gprsState: string
+  onOffStatus: string
+  activatedState: string
+  realPosition: string | null
+  activationTime: string | null
+  endTime: string | null
+}
+
+export interface CardListQuery {
+  keyword?: string
+  status?: string
+  operator?: string
+}
+
+export async function apiGetCards(
+  params: CardListQuery & { page: number; pageSize: number },
+  client: AxiosInstance = request,
+): Promise<{ items: CardItem[]; total: number; page: number; pageSize: number }> {
+  const res = await client.get<ApiResponse<{ items: CardItem[]; total: number; page: number; pageSize: number }>>(
+    '/api/v2/admin/iot/cards',
+    { params },
+  )
+  return res.data.data
+}
+
+export async function apiGetCard(
+  cardNo: string,
+  client: AxiosInstance = request,
+): Promise<CardItem> {
+  const res = await client.get<ApiResponse<CardItem>>(
+    `/api/v2/admin/iot/cards/${encodeURIComponent(cardNo)}`,
+  )
+  return res.data.data
+}
+
+export async function apiSyncCards(
+  client: AxiosInstance = request,
+): Promise<{ cardCount: number }> {
+  const res = await client.post<ApiResponse<{ cardCount: number }>>(
+    '/api/v2/admin/iot/cards/sync',
+  )
+  return res.data.data
+}
+
+export async function apiBatchCards(
+  cardNos: string[],
+  client: AxiosInstance = request,
+): Promise<{ items: CardItem[]; total: number }> {
+  const res = await client.post<ApiResponse<{ items: CardItem[]; total: number }>>(
+    '/api/v2/admin/iot/cards/batch',
+    { cardNos },
+  )
+  return res.data.data
+}
+
+export async function apiGetBalance(
+  client: AxiosInstance = request,
+): Promise<{ amount: string }> {
+  const res = await client.get<ApiResponse<{ amount: string }>>(
+    '/api/v2/admin/iot/cards/balance',
+  )
+  return res.data.data
+}
+
+export async function apiDisableCard(
+  cardNo: string,
+  client: AxiosInstance = request,
+): Promise<void> {
+  await client.put<ApiResponse<void>>(
+    `/api/v2/admin/iot/cards/${encodeURIComponent(cardNo)}/disable`,
+  )
+}
+
+export async function apiEnableCard(
+  cardNo: string,
+  client: AxiosInstance = request,
+): Promise<void> {
+  await client.put<ApiResponse<void>>(
+    `/api/v2/admin/iot/cards/${encodeURIComponent(cardNo)}/enable`,
+  )
+}

--- a/admin/src/router/index.ts
+++ b/admin/src/router/index.ts
@@ -203,6 +203,12 @@ const router = createRouter({
           component: () => import('../views/rbac/menus/index.vue'),
           meta: { permission: 'menu:manage' },
         },
+        {
+          path: '/cms/iot/cards',
+          name: 'iot-cards',
+          component: () => import('../views/iot/cards/index.vue'),
+          meta: { permission: 'iot:card:list' },
+        },
       ],
     },
   ],

--- a/admin/src/views/iot/cards/index.vue
+++ b/admin/src/views/iot/cards/index.vue
@@ -1,0 +1,433 @@
+<script setup lang="ts">
+import { computed, h, ref } from 'vue'
+import axios from 'axios'
+import {
+  NButton,
+  NInput,
+  NSelect,
+  NPopconfirm,
+  NPagination,
+  NSpin,
+  NEmpty,
+  NDataTable,
+  NTag,
+  NDrawer,
+  NDrawerContent,
+  NDescriptions,
+  NDescriptionsItem,
+  NModal,
+  NAlert,
+  useMessage,
+} from 'naive-ui'
+import {
+  SearchOutline,
+  RefreshOutline,
+  CloudUploadOutline,
+} from '@vicons/ionicons5'
+import PageHeader from '../../../components/common/PageHeader.vue'
+import {
+  apiGetCards,
+  apiGetCard,
+  apiSyncCards,
+  apiBatchCards,
+  apiGetBalance,
+  apiDisableCard,
+  apiEnableCard,
+  type CardItem,
+} from '../../../api/iot'
+import { usePermissionStore } from '../../../stores/permission'
+import { useTable } from '../../../composables/useTable'
+
+const message = useMessage()
+const permissionStore = usePermissionStore()
+
+interface CardQuery {
+  keyword: string
+  status: string
+  operator: string
+}
+
+const initialQuery: CardQuery = { keyword: '', status: '', operator: '' }
+
+const table = useTable<CardItem, CardQuery>({
+  fetch: async (params) => {
+    const res = await apiGetCards({
+      page: params.page,
+      pageSize: params.pageSize,
+      keyword: params.keyword || undefined,
+      status: params.status || undefined,
+      operator: params.operator || undefined,
+    })
+    return { list: res.items, total: res.total }
+  },
+  initialQuery,
+  pageSize: 20,
+})
+
+// Status options
+const STATUS_OPTIONS = [
+  { label: '全部状态', value: '' },
+  { label: '在线', value: '1' },
+  { label: '离线', value: '2' },
+  { label: '停机', value: '3' },
+  { label: '机卡分离', value: '4' },
+]
+
+// Operator options
+const OPERATOR_OPTIONS = [
+  { label: '全部运营商', value: '' },
+  { label: '联通', value: '1' },
+  { label: '移动', value: '2' },
+  { label: '电信', value: '3' },
+]
+
+// Balance
+const balance = ref<string | null>(null)
+const balanceLoading = ref(false)
+async function loadBalance() {
+  balanceLoading.value = true
+  try {
+    const res = await apiGetBalance()
+    balance.value = res.amount
+  } catch {
+    balance.value = null
+  } finally {
+    balanceLoading.value = false
+  }
+}
+loadBalance()
+
+// Sync
+const syncLoading = ref(false)
+async function handleSync() {
+  syncLoading.value = true
+  try {
+    const res = await apiSyncCards()
+    message.success(`同步成功，共 ${res.cardCount} 张卡`)
+    table.refresh()
+    loadBalance()
+  } catch (e: unknown) {
+    message.error(extractError(e, '同步失败'))
+  } finally {
+    syncLoading.value = false
+  }
+}
+
+// Batch query dialog
+const batchVisible = ref(false)
+const batchText = ref('')
+const batchLoading = ref(false)
+const batchError = ref<string | null>(null)
+const batchResults = ref<CardItem[]>([])
+
+async function handleBatchQuery() {
+  const lines = batchText.value
+    .split(/[\n,]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+  if (lines.length === 0) {
+    batchError.value = '请输入卡号'
+    return
+  }
+  if (lines.length > 1000) {
+    batchError.value = '最多支持 1000 张卡'
+    return
+  }
+  batchError.value = null
+  batchLoading.value = true
+  try {
+    const res = await apiBatchCards(lines)
+    batchResults.value = res.items
+    if (res.items.length === 0) {
+      batchError.value = '未找到任何卡片'
+    }
+  } catch (e: unknown) {
+    batchError.value = extractError(e, '批量查询失败')
+  } finally {
+    batchLoading.value = false
+  }
+}
+
+// Detail drawer
+const detailVisible = ref(false)
+const detailLoading = ref(false)
+const selectedCard = ref<CardItem | null>(null)
+
+async function handleView(row: CardItem) {
+  detailLoading.value = true
+  detailVisible.value = true
+  selectedCard.value = null
+  try {
+    const res = await apiGetCard(row.cardNo)
+    selectedCard.value = res
+  } catch {
+    // Use row data as fallback
+    selectedCard.value = row
+  } finally {
+    detailLoading.value = false
+  }
+}
+
+// Enable / Disable
+async function handleEnable(row: CardItem) {
+  try {
+    await apiEnableCard(row.cardNo)
+    message.success('卡已启用')
+    table.refresh()
+  } catch (e: unknown) {
+    message.error(extractError(e, '启用失败'))
+  }
+}
+
+async function handleDisable(row: CardItem) {
+  try {
+    await apiDisableCard(row.cardNo)
+    message.success('卡已禁用')
+    table.refresh()
+  } catch (e: unknown) {
+    message.error(extractError(e, '禁用失败'))
+  }
+}
+
+// Status tag helper
+function gprsStateTag(state: string) {
+  const map: Record<string, { label: string; type: string }> = {
+    '1': { label: '在线', type: 'success' },
+    '2': { label: '离线', type: 'default' },
+    '3': { label: '停机', type: 'error' },
+    '4': { label: '机卡分离', type: 'warning' },
+  }
+  const t = map[state] || { label: state || '未知', type: 'default' }
+  return h(NTag, { size: 'small', type: t.type as any }, () => t.label)
+}
+
+function operatorLabel(op: string) {
+  const map: Record<string, string> = { '1': '联通', '2': '移动', '3': '电信' }
+  return map[op] || op || '-'
+}
+
+// Table columns
+const tableColumns = computed(() => [
+  {
+    title: '卡号',
+    key: 'cardNo',
+    width: 160,
+    ellipsis: { tooltip: true },
+  },
+  {
+    title: 'ICCID',
+    key: 'iccid',
+    width: 180,
+    ellipsis: { tooltip: true },
+  },
+  {
+    title: '运营商',
+    key: 'operator',
+    width: 80,
+    render(row: CardItem) {
+      return operatorLabel(row.operator)
+    },
+  },
+  {
+    title: '状态',
+    key: 'gprsState',
+    width: 90,
+    render(row: CardItem) {
+      return gprsStateTag(row.gprsState)
+    },
+  },
+  {
+    title: '套餐',
+    key: 'comboName',
+    width: 140,
+    ellipsis: { tooltip: true },
+  },
+  {
+    title: '剩余(MB)',
+    key: 'comboResidue',
+    width: 100,
+    render(row: CardItem) {
+      const v = row.comboResidue
+      if (v === null || v === undefined) return '-'
+      if (v >= 1024) return (v / 1024).toFixed(1) + ' GB'
+      return v.toFixed(0) + ' MB'
+    },
+  },
+  {
+    title: '操作',
+    key: 'actions',
+    width: 150,
+    render(row: CardItem) {
+      return h('div', { class: 'flex items-center gap-1' }, [
+        h(
+          NButton,
+          { size: 'tiny', quaternary: true, onClick: () => handleView(row) },
+          () => '查看',
+        ),
+        h(
+          NPopconfirm,
+          { 'onPositive-click': () => handleEnable(row) },
+          {
+            trigger: () => permissionStore.hasPermission('iot:card:enable')
+              ? h(NButton, { size: 'tiny', quaternary: true, type: 'success', title: '启用' }, () => '启用')
+              : null,
+            default: () => '确认启用该卡?',
+          },
+        ),
+        h(
+          NPopconfirm,
+          { 'onPositive-click': () => handleDisable(row) },
+          {
+            trigger: () => permissionStore.hasPermission('iot:card:disable')
+              ? h(NButton, { size: 'tiny', quaternary: true, type: 'error', title: '禁用' }, () => '禁用')
+              : null,
+            default: () => '确认禁用该卡?',
+          },
+        ),
+      ])
+    },
+  },
+])
+
+function extractError(e: unknown, fallback: string): string {
+  if (axios.isAxiosError(e)) {
+    const data = e.response?.data as { message?: string } | undefined
+    if (data?.message) return data.message
+  }
+  if (e instanceof Error) return e.message
+  return fallback
+}
+</script>
+
+<template>
+  <div>
+    <PageHeader title="物联网卡管理" :subtitle="balance ? `账户余额: ¥${balance}` : undefined">
+      <NButton v-permission="'iot:card:list'" type="primary" :loading="syncLoading" @click="handleSync">
+        <CloudUploadOutline class="w-4 h-4 mr-1" />
+        同步
+      </NButton>
+      <NButton v-permission="'iot:card:list'" @click="batchVisible = true">
+        批量查询
+      </NButton>
+    </PageHeader>
+
+    <!-- Search & Filter -->
+    <div class="flex flex-wrap items-center gap-3 mb-5">
+      <div class="relative flex-1 min-w-[200px] max-w-[320px]">
+        <NInput
+          v-model:value="table.query.keyword"
+          placeholder="搜索卡号 / MSISDN / ICCID"
+          clearable
+        >
+          <template #prefix>
+            <SearchOutline class="w-4 h-4 text-base-content/30" />
+          </template>
+        </NInput>
+      </div>
+      <NSelect
+        v-model:value="table.query.status"
+        :options="STATUS_OPTIONS"
+        placeholder="状态"
+        clearable
+        style="width: 130px"
+      />
+      <NSelect
+        v-model:value="table.query.operator"
+        :options="OPERATOR_OPTIONS"
+        placeholder="运营商"
+        clearable
+        style="width: 130px"
+      />
+      <NButton quaternary circle :loading="table.loading.value" @click="table.refresh()">
+        <RefreshOutline class="w-4 h-4" />
+      </NButton>
+    </div>
+
+    <!-- Table -->
+    <NSpin :show="table.loading.value">
+      <div v-if="table.data.value.length === 0 && !table.loading.value" class="py-16">
+        <NEmpty description="暂无物联网卡">
+          <template #extra>
+            <p class="text-sm text-base-content/40 mt-2">点击右上角"同步"从IoT平台同步卡片数据</p>
+          </template>
+        </NEmpty>
+      </div>
+
+      <NDataTable
+        v-else
+        :columns="tableColumns"
+        :data="table.data.value"
+        :loading="table.loading.value"
+        :bordered="false"
+        :single-line="false"
+        striped
+        size="small"
+        class="rounded-xl overflow-hidden"
+      />
+    </NSpin>
+
+    <!-- Pagination -->
+    <div v-if="table.total.value > 0" class="mt-6 flex justify-end">
+      <NPagination
+        :page="table.page.value"
+        :page-size="table.pageSize.value"
+        :item-count="table.total.value"
+        :page-sizes="[20, 50, 100]"
+        show-size-picker
+        @update:page="table.handlePageChange"
+        @update:page-size="table.handlePageSizeChange"
+      />
+    </div>
+
+    <!-- Detail Drawer -->
+    <NDrawer v-model:show="detailVisible" :width="420" placement="right">
+      <NDrawerContent title="卡片详情" closable>
+        <NSpin :show="detailLoading">
+          <NDescriptions v-if="selectedCard" :column="1" label-placement="left" size="large">
+            <NDescriptionsItem label="卡号">{{ selectedCard.cardNo }}</NDescriptionsItem>
+            <NDescriptionsItem label="MSISDN">{{ selectedCard.msisdn || '-' }}</NDescriptionsItem>
+            <NDescriptionsItem label="ICCID">{{ selectedCard.iccid || '-' }}</NDescriptionsItem>
+            <NDescriptionsItem label="IMSI">{{ selectedCard.imsi || '-' }}</NDescriptionsItem>
+            <NDescriptionsItem label="运营商">{{ operatorLabel(selectedCard.operator) }}</NDescriptionsItem>
+            <NDescriptionsItem label="卡形态">{{ selectedCard.cardType || '-' }}</NDescriptionsItem>
+            <NDescriptionsItem label="套餐">{{ selectedCard.comboName || '-' }}</NDescriptionsItem>
+            <NDescriptionsItem label="已用">{{ selectedCard.comboUsed != null ? selectedCard.comboUsed + ' MB' : '-' }}</NDescriptionsItem>
+            <NDescriptionsItem label="剩余">{{ selectedCard.comboResidue != null ? selectedCard.comboResidue + ' MB' : '-' }}</NDescriptionsItem>
+            <NDescriptionsItem label="总量">{{ selectedCard.comboTotal != null ? selectedCard.comboTotal + ' MB' : '-' }}</NDescriptionsItem>
+            <NDescriptionsItem label="联网状态">{{ gprsStateTag(selectedCard.gprsState) }}</NDescriptionsItem>
+            <NDescriptionsItem label="设备状态">{{ selectedCard.onOffStatus === '1' ? '在线' : selectedCard.onOffStatus === '0' ? '离线' : '-' }}</NDescriptionsItem>
+            <NDescriptionsItem label="激活状态">{{ selectedCard.activatedState === '1' ? '测试期' : selectedCard.activatedState === '2' ? '库存期' : selectedCard.activatedState === '3' ? '已激活' : '-' }}</NDescriptionsItem>
+            <NDescriptionsItem label="实时位置">{{ selectedCard.realPosition || '-' }}</NDescriptionsItem>
+            <NDescriptionsItem label="激活时间">{{ selectedCard.activationTime || '-' }}</NDescriptionsItem>
+            <NDescriptionsItem label="到期时间">{{ selectedCard.endTime || '-' }}</NDescriptionsItem>
+          </NDescriptions>
+        </NSpin>
+      </NDrawerContent>
+    </NDrawer>
+
+    <!-- Batch Query Modal -->
+    <NModal v-model:show="batchVisible" preset="card" title="批量查询卡片" style="width: 600px">
+      <NAlert v-if="batchError" type="error" class="mb-4">{{ batchError }}</NAlert>
+      <NInput
+        v-model:value="batchText"
+        type="textarea"
+        placeholder="输入卡号，每行一个或逗号分隔（最多1000个）"
+        :rows="6"
+        class="mb-4"
+      />
+      <div class="flex justify-end gap-2">
+        <NButton @click="batchVisible = false">取消</NButton>
+        <NButton type="primary" :loading="batchLoading" @click="handleBatchQuery">查询</NButton>
+      </div>
+      <NSpin v-if="batchLoading" class="mt-4" />
+      <NDataTable
+        v-if="!batchLoading && batchResults.length > 0"
+        :columns="tableColumns"
+        :data="batchResults"
+        class="mt-4 rounded-xl overflow-hidden"
+        size="small"
+        :pagination="false"
+      />
+    </NModal>
+  </div>
+</template>

--- a/server/src/apps/admin/iot/cardHandlers.js
+++ b/server/src/apps/admin/iot/cardHandlers.js
@@ -1,0 +1,306 @@
+/**
+ * IoT Card handlers.
+ * All card data is persisted locally in SQLite (iot_cards table).
+ * Reads/writes from local DB; enable/disable are proxied to the IoT platform.
+ */
+const { openDb } = require("../../../db");
+const { nowIso } = require("../../../utils");
+const { getCardInfo, getCardInfoBatch, disableCard, enableCard, getAmount } = require("../../../modules/iotService");
+
+function mapCard(raw) {
+  return {
+    cardNo:        raw.cardNo,
+    msisdn:        raw.msisdn,
+    imsi:          raw.imsi,
+    iccid:         raw.iccid,
+    operator:      raw.operator,
+    cardType:      raw.type,
+    comboName:     raw.comboName,
+    comboResidue:  parseFloat(raw.comboResidue || "0"),
+    comboUsed:     parseFloat(raw.comboUsed || "0"),
+    comboTotal:    parseFloat(raw.comboTotal || "0"),
+    status:        raw.status,
+    gprsState:     raw.gprsState,
+    onOffStatus:   raw.onOffStatus,
+    activatedState: raw.activatedState,
+    realPosition:  raw.realPosition || null,
+    activationTime: raw.activationTime || null,
+    endTime:       raw.endTime || null,
+  };
+}
+
+// GET /api/v2/admin/iot/cards
+async function listCards(req, res) {
+  const db = openDb();
+  const page = Math.max(1, parseInt(req.query.page || "1", 10));
+  const pageSize = Math.min(100, Math.max(1, parseInt(req.query.pageSize || "20", 10)));
+  const keyword = String(req.query.keyword || "").trim() || null;
+  const status = String(req.query.status || "").trim() || null;
+  const operator = String(req.query.operator || "").trim() || null;
+
+  const conditions = ["1=1"];
+  const params = [];
+  if (keyword) {
+    conditions.push("(card_no LIKE ? OR msisdn LIKE ? OR iccid LIKE ?)");
+    const like = `%${keyword}%`;
+    params.push(like, like, like);
+  }
+  if (status) conditions.push("status = ?"), params.push(status);
+  if (operator) conditions.push("operator = ?"), params.push(operator);
+
+  const where = conditions.join(" AND ");
+  const total = db.prepare(`SELECT COUNT(*) AS c FROM iot_cards WHERE ${where}`).get(...params).c;
+  const offset = (page - 1) * pageSize;
+  const rows = db
+    .prepare(`SELECT * FROM iot_cards WHERE ${where} ORDER BY id DESC LIMIT ? OFFSET ?`)
+    .all(...params, pageSize, offset);
+
+  const items = rows.map((r) => ({
+    cardNo:        r.card_no,
+    msisdn:        r.msisdn,
+    imsi:          r.imsi,
+    iccid:         r.iccid,
+    operator:      r.operator,
+    cardType:      r.card_type,
+    comboName:     r.combo_name,
+    comboResidue:  r.combo_residue,
+    comboUsed:     r.combo_used,
+    comboTotal:    r.combo_total,
+    status:        r.status,
+    gprsState:     r.gprs_state,
+    onOffStatus:   r.on_off_status,
+    activatedState: r.activated_state,
+    realPosition:  r.real_position,
+    activationTime: r.activation_time,
+    endTime:       r.end_time,
+  }));
+
+  return res.status(200).json({ code: 200, message: "success", data: { items, total, page, pageSize } });
+}
+
+// GET /api/v2/admin/iot/cards/:cardNo
+async function getCard(req, res) {
+  const { cardNo } = req.params;
+  const db = openDb();
+  const row = db.prepare(`SELECT * FROM iot_cards WHERE card_no = ?`).get(cardNo);
+  if (!row) return res.status(404).json({ code: 404, message: "Card not found" });
+
+  const data = {
+    cardNo:        row.card_no,
+    msisdn:        row.msisdn,
+    imsi:          row.imsi,
+    iccid:         row.iccid,
+    operator:      row.operator,
+    cardType:      row.card_type,
+    comboName:     row.combo_name,
+    comboResidue:  row.combo_residue,
+    comboUsed:     row.combo_used,
+    comboTotal:    row.combo_total,
+    status:        row.status,
+    gprsState:     row.gprs_state,
+    onOffStatus:   row.on_off_status,
+    activatedState: row.activated_state,
+    realPosition:  row.real_position,
+    activationTime: row.activation_time,
+    endTime:       row.end_time,
+  };
+  return res.status(200).json({ code: 200, message: "success", data });
+}
+
+// POST /api/v2/admin/iot/cards/sync
+async function syncCards(req, res) {
+  const db = openDb();
+  const now = nowIso();
+
+  // Read all card numbers from local DB to batch query
+  const rows = db.prepare(`SELECT card_no FROM iot_cards`).all();
+  if (rows.length === 0) {
+    return res.status(200).json({ code: 200, message: "No cards to sync", data: { cardCount: 0 } });
+  }
+
+  const cardNos = rows.map((r) => r.card_no);
+  let result;
+  try {
+    result = await getCardInfoBatch(cardNos);
+  } catch (e) {
+    db.prepare(`INSERT INTO iot_sync_logs (synced_at, card_count, result) VALUES (?, 0, ?)`).run(now, String(e.message));
+    return res.status(503).json({ code: 503, message: "IoT platform error: " + e.message });
+  }
+
+  const cards = Array.isArray(result.data) ? result.data : [];
+  const upsert = db.prepare(`
+    INSERT INTO iot_cards (card_no, msisdn, imsi, iccid, operator, card_type, combo_name,
+      combo_residue, combo_used, combo_total, status, gprs_state, on_off_status,
+      activated_state, real_position, activation_time, end_time, created_at, updated_at)
+    VALUES (@card_no, @msisdn, @imsi, @iccid, @operator, @card_type, @combo_name,
+      @combo_residue, @combo_used, @combo_total, @status, @gprs_state, @on_off_status,
+      @activated_state, @real_position, @activation_time, @end_time, @created_at, @updated_at)
+    ON CONFLICT(card_no) DO UPDATE SET
+      msisdn=excluded.msisdn, imsi=excluded.imsi, iccid=excluded.iccid,
+      operator=excluded.operator, card_type=excluded.card_type, combo_name=excluded.combo_name,
+      combo_residue=excluded.combo_residue, combo_used=excluded.combo_used,
+      combo_total=excluded.combo_total, status=excluded.status,
+      gprs_state=excluded.gprs_state, on_off_status=excluded.on_off_status,
+      activated_state=excluded.activated_state, real_position=excluded.real_position,
+      activation_time=excluded.activation_time, end_time=excluded.end_time,
+      updated_at=excluded.updated_at
+  `);
+
+  const upsertMany = db.transaction((cards) => {
+    for (const c of cards) {
+      const mapped = mapCard(c);
+      upsert.run({
+        card_no:        mapped.cardNo,
+        msisdn:         mapped.msisdn,
+        imsi:           mapped.imsi,
+        iccid:          mapped.iccid,
+        operator:       mapped.operator,
+        card_type:      mapped.cardType,
+        combo_name:     mapped.comboName,
+        combo_residue:  mapped.comboResidue,
+        combo_used:     mapped.comboUsed,
+        combo_total:    mapped.comboTotal,
+        status:         mapped.status,
+        gprs_state:     mapped.gprsState,
+        on_off_status:  mapped.onOffStatus,
+        activated_state: mapped.activatedState,
+        real_position:  mapped.realPosition,
+        activation_time: mapped.activationTime,
+        end_time:       mapped.endTime,
+        created_at:     now,
+        updated_at:     now,
+      });
+    }
+  });
+
+  upsertMany(cards);
+  db.prepare(`INSERT INTO iot_sync_logs (synced_at, card_count, result) VALUES (?, ?, 'ok')`).run(now, cards.length);
+
+  return res.status(200).json({ code: 200, message: "success", data: { cardCount: cards.length } });
+}
+
+// POST /api/v2/admin/iot/cards/batch
+async function batchCards(req, res) {
+  const { cardNos } = req.body;
+  if (!Array.isArray(cardNos) || cardNos.length === 0) {
+    return res.status(400).json({ code: 400, message: "cardNos must be a non-empty array (max 1000)" });
+  }
+  if (cardNos.length > 1000) {
+    return res.status(400).json({ code: 400, message: "Maximum 1000 cards per batch query" });
+  }
+
+  let result;
+  try {
+    result = await getCardInfoBatch(cardNos);
+  } catch (e) {
+    return res.status(503).json({ code: 503, message: "IoT platform error: " + e.message });
+  }
+
+  const db = openDb();
+  const now = nowIso();
+  const cards = Array.isArray(result.data) ? result.data : [];
+  const upsert = db.prepare(`
+    INSERT INTO iot_cards (card_no, msisdn, imsi, iccid, operator, card_type, combo_name,
+      combo_residue, combo_used, combo_total, status, gprs_state, on_off_status,
+      activated_state, real_position, activation_time, end_time, created_at, updated_at)
+    VALUES (@card_no, @msisdn, @imsi, @iccid, @operator, @card_type, @combo_name,
+      @combo_residue, @combo_used, @combo_total, @status, @gprs_state, @on_off_status,
+      @activated_state, @real_position, @activation_time, @end_time, @created_at, @updated_at)
+    ON CONFLICT(card_no) DO UPDATE SET
+      msisdn=excluded.msisdn, imsi=excluded.imsi, iccid=excluded.iccid,
+      operator=excluded.operator, card_type=excluded.card_type, combo_name=excluded.combo_name,
+      combo_residue=excluded.combo_residue, combo_used=excluded.combo_used,
+      combo_total=excluded.combo_total, status=excluded.status,
+      gprs_state=excluded.gprs_state, on_off_status=excluded.on_off_status,
+      activated_state=excluded.activated_state, real_position=excluded.real_position,
+      activation_time=excluded.activation_time, end_time=excluded.end_time,
+      updated_at=excluded.updated_at
+  `);
+
+  const upsertMany = db.transaction((cards) => {
+    for (const c of cards) {
+      const mapped = mapCard(c);
+      upsert.run({
+        card_no:        mapped.cardNo,
+        msisdn:         mapped.msisdn,
+        imsi:           mapped.imsi,
+        iccid:          mapped.iccid,
+        operator:       mapped.operator,
+        card_type:      mapped.cardType,
+        combo_name:     mapped.comboName,
+        combo_residue:  mapped.comboResidue,
+        combo_used:     mapped.comboUsed,
+        combo_total:    mapped.comboTotal,
+        status:         mapped.status,
+        gprs_state:     mapped.gprsState,
+        on_off_status:  mapped.onOffStatus,
+        activated_state: mapped.activatedState,
+        real_position:  mapped.realPosition,
+        activation_time: mapped.activationTime,
+        end_time:       mapped.endTime,
+        created_at:     now,
+        updated_at:     now,
+      });
+    }
+  });
+
+  upsertMany(cards);
+
+  return res.status(200).json({
+    code: 200,
+    message: "success",
+    data: { items: cards.map(mapCard), total: cards.length },
+  });
+}
+
+// GET /api/v2/admin/iot/cards/balance
+async function getBalance(req, res) {
+  try {
+    const result = await getAmount();
+    return res.status(200).json({
+      code: 200,
+      message: "success",
+      data: { amount: result.data?.amount ?? "0" },
+    });
+  } catch (e) {
+    return res.status(503).json({ code: 503, message: "Failed to query balance: " + e.message });
+  }
+}
+
+// PUT /api/v2/admin/iot/cards/:cardNo/disable
+async function disableCardHandler(req, res) {
+  const { cardNo } = req.params;
+  try {
+    const result = await disableCard(cardNo);
+    if (result.code !== 0) {
+      return res.status(400).json({ code: result.code, message: result.msg || "Disable failed" });
+    }
+    return res.status(200).json({ code: 200, message: result.msg || "Card disabled", data: { cardNo } });
+  } catch (e) {
+    return res.status(503).json({ code: 503, message: "IoT platform error: " + e.message });
+  }
+}
+
+// PUT /api/v2/admin/iot/cards/:cardNo/enable
+async function enableCardHandler(req, res) {
+  const { cardNo } = req.params;
+  try {
+    const result = await enableCard(cardNo);
+    if (result.code !== 0) {
+      return res.status(400).json({ code: result.code, message: result.msg || "Enable failed" });
+    }
+    return res.status(200).json({ code: 200, message: result.msg || "Card enabled", data: { cardNo } });
+  } catch (e) {
+    return res.status(503).json({ code: 503, message: "IoT platform error: " + e.message });
+  }
+}
+
+module.exports = {
+  listCards,
+  getCard,
+  syncCards,
+  batchCards,
+  getBalance,
+  disableCard: disableCardHandler,
+  enableCard: enableCardHandler,
+};

--- a/server/src/apps/admin/iot/cardsRouter.js
+++ b/server/src/apps/admin/iot/cardsRouter.js
@@ -1,0 +1,24 @@
+const express = require("express");
+const {
+  listCards,
+  getCard,
+  syncCards,
+  batchCards,
+  getBalance,
+  disableCard,
+  enableCard,
+} = require("./cardHandlers");
+const jwtAuth = require("../../../middleware/jwtAuth");
+const requirePermission = require("../../../middleware/rbac");
+
+const router = express.Router();
+
+router.get("/",              jwtAuth, requirePermission("iot:card:list"),   listCards);
+router.get("/balance",      jwtAuth, requirePermission("iot:card:list"),   getBalance);
+router.post("/sync",        jwtAuth, requirePermission("iot:card:list"),   syncCards);
+router.post("/batch",       jwtAuth, requirePermission("iot:card:list"),   batchCards);
+router.get("/:cardNo",      jwtAuth, requirePermission("iot:card:query"),  getCard);
+router.put("/:cardNo/disable", jwtAuth, requirePermission("iot:card:disable"), disableCard);
+router.put("/:cardNo/enable",  jwtAuth, requirePermission("iot:card:enable"),  enableCard);
+
+module.exports = router;

--- a/server/src/apps/adminApp.js
+++ b/server/src/apps/adminApp.js
@@ -25,6 +25,7 @@ const tasksRouter = require("./admin/kb/tasksRouter");
 const templatesRouter = require("./admin/kb/templatesRouter");
 const webSearchRouter = require("./admin/kb/webSearchRouter");
 const settingsRouter = require("./admin/settings/settingsRouter");
+const iotCardsRouter = require("./admin/iot/cardsRouter");
 
 const app = express();
 
@@ -89,6 +90,7 @@ v2Router.use("/admin/kb/tasks", tasksRouter);
 v2Router.use("/admin/kb/templates", templatesRouter);
 v2Router.use("/admin/kb/search", webSearchRouter);
 v2Router.use("/admin/settings", settingsRouter);
+v2Router.use("/admin/iot/cards", iotCardsRouter);
 
 // ---- Open WebUI 代理配置 ----
 // 代理 API 请求到 Open WebUI FastAPI 后端

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -540,6 +540,44 @@ function migrate(db) {
     );
   }
 
+  // ============================================================
+  // Phase 10: IoT Card Management (物联网卡管理)
+  // ============================================================
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS iot_cards (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      card_no TEXT UNIQUE NOT NULL,
+      msisdn TEXT,
+      imsi TEXT,
+      iccid TEXT,
+      operator TEXT,
+      card_type TEXT,
+      combo_name TEXT,
+      combo_residue REAL,
+      combo_used REAL,
+      combo_total REAL,
+      status TEXT,
+      gprs_state TEXT,
+      on_off_status TEXT,
+      activated_state TEXT,
+      real_position TEXT,
+      activation_time TEXT,
+      end_time TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_iot_cards_status ON iot_cards(status);
+    CREATE INDEX IF NOT EXISTS idx_iot_cards_operator ON iot_cards(operator);
+
+    CREATE TABLE IF NOT EXISTS iot_sync_logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      synced_at TEXT NOT NULL,
+      card_count INTEGER NOT NULL DEFAULT 0,
+      result TEXT NOT NULL DEFAULT 'ok'
+    );
+    CREATE INDEX IF NOT EXISTS idx_iot_sync_logs_synced_at ON iot_sync_logs(synced_at);
+  `);
+
 }
 
 function ensureSeed(db) {

--- a/server/src/env.js
+++ b/server/src/env.js
@@ -12,4 +12,8 @@ function optional(name, fallback) {
 module.exports = {
   required,
   optional,
+  // IoT platform (物联网卡管理)
+  IOT_API_BASE_URL: optional("IOT_API_BASE_URL", ""),
+  IOT_APP_ID:       optional("IOT_APP_ID", ""),
+  IOT_APP_SECRET:   optional("IOT_APP_SECRET", ""),
 };

--- a/server/src/modules/iotService.js
+++ b/server/src/modules/iotService.js
@@ -1,0 +1,84 @@
+/**
+ * IoT platform service layer.
+ * Wraps all IoT API calls with token injection and response normalization.
+ */
+const axios = require("axios");
+const { optional } = require("../env");
+const { getIotToken } = require("./iotToken");
+
+function buildClient() {
+  const baseURL = optional("IOT_API_BASE_URL") || "";
+  const instance = axios.create({ baseURL, timeout: 10_000 });
+
+  instance.interceptors.request.use(async (config) => {
+    const token = await getIotToken();
+    config.headers["token"] = token;
+    return config;
+  });
+
+  return instance;
+}
+
+// Normalize IoT platform response to internal format
+// IoT returns { code: 0, msg: "string", data: {...} }
+function normalizeResponse(iotRes) {
+  return iotRes.data;
+}
+
+async function iotGet(path, params) {
+  const client = buildClient();
+  const res = await client.get(path, { params });
+  return normalizeResponse(res);
+}
+
+async function iotPost(path, data) {
+  const client = buildClient();
+  const res = await client.post(path, data);
+  return normalizeResponse(res);
+}
+
+// ----- Auth -----
+async function fetchToken() {
+  const baseUrl = optional("IOT_API_BASE_URL");
+  const appId = optional("IOT_APP_ID");
+  const appSecret = optional("IOT_APP_SECRET");
+  if (!baseUrl || !appId || !appSecret) {
+    throw new Error("IOT platform credentials not configured");
+  }
+  const res = await axios.post(`${baseUrl}/auth/login`, {
+    appId,
+    appSecret,
+    ts: Date.now(),
+  });
+  return res.headers["token"];
+}
+
+// ----- Card -----
+async function getCardInfo(cardNo) {
+  return iotPost("/v1/external/card/getCardInfo", { cardNo });
+}
+
+async function getCardInfoBatch(cardNos) {
+  return iotPost("/v1/external/card/getCardInfoBatch", { cardNos });
+}
+
+async function disableCard(cardNo) {
+  return iotPost("/v1/external/card/disable", { cardNo });
+}
+
+async function enableCard(cardNo) {
+  return iotPost("/v1/external/card/enabled", { cardNo });
+}
+
+// ----- Balance -----
+async function getAmount() {
+  return iotPost("/v1/external/customer/getAmount", {});
+}
+
+module.exports = {
+  getCardInfo,
+  getCardInfoBatch,
+  disableCard,
+  enableCard,
+  getAmount,
+};

--- a/server/src/modules/iotToken.js
+++ b/server/src/modules/iotToken.js
@@ -1,0 +1,59 @@
+/**
+ * IoT platform token manager.
+ * Caches the access token returned in response header "token" from POST /auth/login.
+ * Auto-refreshes 2 minutes before the 15-minute expiry.
+ */
+const axios = require("axios");
+const { optional } = require("../env");
+
+let _token = null;
+let _expiresAt = null;
+
+async function getIotToken() {
+  const baseUrl = optional("IOT_API_BASE_URL");
+  if (!baseUrl) {
+    throw new Error("IOT_API_BASE_URL is not configured");
+  }
+
+  const now = Date.now();
+  // Refresh if missing or expires within 2 minutes
+  if (!_token || !_expiresAt || now >= _expiresAt - 120_000) {
+    await refreshToken();
+  }
+  return _token;
+}
+
+async function refreshToken() {
+  const axios = require("axios");
+  const baseUrl = optional("IOT_API_BASE_URL");
+  const appId = optional("IOT_APP_ID");
+  const appSecret = optional("IOT_APP_SECRET");
+
+  if (!baseUrl || !appId || !appSecret) {
+    throw new Error("IoT platform credentials not configured (IOT_API_BASE_URL, IOT_APP_ID, IOT_APP_SECRET)");
+  }
+
+  const res = await axios.post(`${baseUrl}/auth/login`, {
+    appId,
+    appSecret,
+    ts: Date.now(),
+  });
+
+  const token = res.headers["token"];
+  if (!token) {
+    throw new Error("IoT platform returned no token in response header");
+  }
+
+  _token = token;
+  // Set expiry to now + 15 minutes (per spec)
+  _expiresAt = Date.now() + 15 * 60 * 1000;
+  console.log("[IoT] Token refreshed, expires at", new Date(_expiresAt).toISOString());
+}
+
+async function forceRefresh() {
+  _token = null;
+  _expiresAt = null;
+  return getIotToken();
+}
+
+module.exports = { getIotToken, forceRefresh };

--- a/server/src/seeds/rbacSeed.js
+++ b/server/src/seeds/rbacSeed.js
@@ -65,6 +65,10 @@ const PERMISSIONS = [
   { code: "ai:chat",       resource: "ai",         action: "chat",    name: "AI 对话",         description: "与 AI 模型对话" },
   { code: "ai:model",      resource: "ai",         action: "model",  name: "管理 AI 模型",    description: "配置和管理 AI 模型" },
   { code: "task:manage",   resource: "task",       action: "manage", name: "管理任务看板",     description: "创建、编辑、删除任务看板中的任务" },
+  { code: "iot:card:list",    resource: "iot:card",  action: "list",    name: "查看物联网卡列表",  description: "浏览物联网卡列表" },
+  { code: "iot:card:query",   resource: "iot:card",  action: "query",   name: "查询物联网卡详情",  description: "查看单张物联网卡详细信息" },
+  { code: "iot:card:enable",  resource: "iot:card",  action: "enable",  name: "启用物联网卡",      description: "恢复物联网卡通信功能" },
+  { code: "iot:card:disable", resource: "iot:card",  action: "disable", name: "禁用物联网卡",      description: "强制断开物联网卡通信" },
 ];
 
 // ============================================================
@@ -81,13 +85,13 @@ const ROLES = [
     code: "content_admin",
     name: "内容管理员",
     description: "可管理博客内容（文章 / 标签 / 分类 / 友链）",
-    permissions: ["post:list", "post:create", "post:update", "post:delete", "post:publish", "tag:list", "tag:create", "tag:update", "tag:delete", "category:list", "category:create", "category:update", "category:delete", "link:list", "link:create", "link:update", "link:delete", "media:upload", "media:delete", "analytics:view"],
+    permissions: ["post:list", "post:create", "post:update", "post:delete", "post:publish", "tag:list", "tag:create", "tag:update", "tag:delete", "category:list", "category:create", "category:update", "category:delete", "link:list", "link:create", "link:update", "link:delete", "media:upload", "media:delete", "analytics:view", "iot:card:list"],
   },
   {
     code: "viewer",
     name: "访客/只读",
     description: "只能浏览数据，不能修改",
-    permissions: ["post:list", "user:list", "analytics:view", "ops:logs", "ops:monitor"],
+    permissions: ["post:list", "user:list", "analytics:view", "ops:logs", "ops:monitor", "iot:card:list"],
   },
 ];
 
@@ -144,6 +148,9 @@ const MENUS = [
     ],
   },
   { name: "数据导入导出", path: "/cms/backup",   icon: "ArchiveOutline",     permission: "cms:export",     sort: 8 },
+  {
+    name: "物联网卡管理", path: "/cms/iot/cards", icon: "GridOutline",  permission: "iot:card:list", sort: 9,
+  },
 ];
 
 // ============================================================


### PR DESCRIPTION
## Summary

- Add IoT card management module to admin panel with local SQLite persistence
- Sync card data from IoT platform API, supports enable/disable operations

## Changes

**Backend:**
- `server/src/modules/iotToken.js` — Token manager (15min cache, auto-refresh)
- `server/src/modules/iotService.js` — Service layer wrapping IoT platform API calls
- `server/src/apps/admin/iot/cardHandlers.js` — Handlers: list/get/sync/batch/balance/disable/enable
- `server/src/apps/admin/iot/cardsRouter.js` — RBAC-protected Express routes
- `server/src/db.js` — Added `iot_cards` + `iot_sync_logs` tables
- `server/src/env.js` — Added `IOT_API_BASE_URL`, `IOT_APP_ID`, `IOT_APP_SECRET`
- `server/src/seeds/rbacSeed.js` — 4 IoT permissions + menu entry

**Frontend:**
- `admin/src/api/iot.ts` — Typed API client
- `admin/src/views/iot/cards/index.vue` — Table view with search/filters, sync, batch modal, detail drawer

## Test plan

- [ ] Login as super admin → verify 物联网卡管理 appears in sidebar
- [ ] Click 同步 → cards sync from IoT platform
- [ ] Click 批量查询 → enter card numbers → results display
- [ ] Click 查看 → NDrawer shows card detail
- [ ] Test 启用/禁用 with popconfirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)