### PR TITLE
feat(kb): extend obsidian sync to scan both wiki/ and notes/ directories

### DIFF
--- a/server/src/apps/admin/kb/syncEngine.js
+++ b/server/src/apps/admin/kb/syncEngine.js
@@ -24,9 +24,10 @@ function computeChecksum(content) {
 }
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const CONTENT_DIRS = ['wiki', 'notes'];
 
 /**
- * Recursively scan the wiki/ subdirectory for .md files, returning file info with checksums.
+ * Recursively scan content directories (wiki/, notes/) for .md files, returning file info with checksums.
  */
 function matchSelectedPaths(relPath, selectedPaths) {
   if (!selectedPaths || selectedPaths.length === 0) return true; // no filter = include all
@@ -43,41 +44,42 @@ function matchSelectedPaths(relPath, selectedPaths) {
 
 function scanVault(vaultPath, selectedPaths) {
   const results = [];
-  const wikiPath = path.join(vaultPath, "wiki");
-  if (!fs.existsSync(wikiPath)) { console.log(`[kb-sync] scanVault: wikiPath not found: ${wikiPath}`); return results; }
-
-  const resolved = path.resolve(wikiPath);
-  const normalized = path.normalize(resolved).toLowerCase();
   let scanned = 0, matched = 0;
 
-  function walk(dir) {
-    if (dir.length > 4000) return;
-    let entries;
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch (e) {
-      console.log(`[kb-sync] scanVault: cannot read dir ${dir}: ${e.message}`); return;
-    }
-    for (const e of entries) {
-      if (e.name.startsWith(".")) continue;
-      const full = path.join(dir, e.name);
-      const real = path.resolve(full).toLowerCase();
-      if (!real.startsWith(normalized + path.sep) && real !== normalized) {
-        console.log(`[kb-sync] scanVault: symlink/escape blocked: ${full} (real=${real})`); continue;
+  for (const dir of CONTENT_DIRS) {
+    const dirPath = path.join(vaultPath, dir);
+    if (!fs.existsSync(dirPath)) { console.log(`[kb-sync] scanVault: ${dir} not found: ${dirPath}`); continue; }
+
+    const resolved = path.resolve(dirPath);
+    const normalized = path.normalize(resolved).toLowerCase();
+
+    function walk(dir) {
+      if (dir.length > 4000) return;
+      let entries;
+      try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (e) { console.log(`[kb-sync] scanVault: cannot read dir ${dir}: ${e.message}`); return; }
+      for (const e of entries) {
+        if (e.name.startsWith(".")) continue;
+        const full = path.join(dir, e.name);
+        const real = path.resolve(full).toLowerCase();
+        if (!real.startsWith(normalized + path.sep) && real !== normalized) {
+          console.log(`[kb-sync] scanVault: symlink/escape blocked: ${full} (real=${real})`); continue;
+        }
+        if (e.isDirectory()) {
+          walk(full);
+        } else if (e.isFile() && e.name.endsWith(".md")) {
+          scanned++;
+          const relPath = path.relative(dirPath, full).replace(/\\/g, "/");
+          const prefixed = dir + "/" + relPath;
+          if (!matchSelectedPaths(prefixed, selectedPaths)) continue;
+          matched++;
+          const content = fs.readFileSync(full, "utf8");
+          results.push({ relativePath: prefixed, content, checksum: computeChecksum(content), size: fs.statSync(full).size });
+        }
       }
-      if (e.isDirectory()) {
-        walk(full);
-      } else if (e.isFile() && e.name.endsWith(".md")) {
-        scanned++;
-        const relPath = path.relative(wikiPath, full).replace(/\\/g, "/");
-        if (!matchSelectedPaths(relPath, selectedPaths)) continue;
-        matched++;
-        const content = fs.readFileSync(full, "utf8");
-        results.push({ relativePath: relPath, content, checksum: computeChecksum(content), size: fs.statSync(full).size });
-      }
     }
+    walk(dirPath);
   }
-  walk(wikiPath);
+
   console.log(`[kb-sync] scanVault: scanned=${scanned} matched=${matched} results=${results.length} selected=${JSON.stringify(selectedPaths)}`);
   return results;
 }
@@ -127,9 +129,11 @@ function importDocument(db, fileInfo, conflictStrategy, now, source) {
   const reviewStatus = ["seed", "developing", "mature"].includes(attributes.status)
     ? attributes.status : null;
 
-  // Extract category from the first path segment (subdirectory under wiki/)
+  // Extract category from the first path segment under the content dir
+  // e.g., "wiki/project-a/file.md" → "project-a", "notes/daily/todo.md" → "daily"
   const parts = fileInfo.relativePath.split("/");
-  const category = parts.length > 1 ? parts[0] : null;
+  const catStart = parts.length > 0 && CONTENT_DIRS.includes(parts[0]) ? 1 : 0;
+  const category = parts.length > catStart + 1 ? parts[catStart] : null;
 
   const existing = db
     .prepare("SELECT * FROM kb_documents WHERE original_path = ? AND source = ?")
@@ -248,8 +252,7 @@ async function fullImport(vaultPath, conflictStrategy, selectedPaths) {
   const db = openDb();
   const now = new Date().toISOString();
   try {
-    const wikiPath = path.join(vaultPath, "wiki");
-    console.log(`[kb-sync] fullImport starting: vault=${vaultPath} wiki=${wikiPath} selected=${JSON.stringify(selectedPaths)} wikiExists=${fs.existsSync(wikiPath)}`);
+    console.log(`[kb-sync] fullImport starting: vault=${vaultPath} dirs=${JSON.stringify(CONTENT_DIRS)} selected=${JSON.stringify(selectedPaths)}`);
     const files = scanVault(vaultPath, selectedPaths);
     console.log(`[kb-sync] scanVault found ${files.length} files, starting import...`);
     const result = await importFromFiles(files, conflictStrategy, "obsidian");
@@ -271,40 +274,40 @@ async function fullImport(vaultPath, conflictStrategy, selectedPaths) {
 }
 
 /**
- * Lightweight scan: only return file paths (no content) from wiki/ subdirectory, for building file trees.
+ * Lightweight scan: only return file paths (no content) from content directories, for building file trees.
  */
 function scanVaultPaths(vaultPath) {
   const results = [];
-  const wikiPath = path.join(vaultPath, "wiki");
-  if (!fs.existsSync(wikiPath)) return results;
 
-  const resolved = path.resolve(wikiPath);
-  const normalized = path.normalize(resolved).toLowerCase();
+  for (const dir of CONTENT_DIRS) {
+    const dirPath = path.join(vaultPath, dir);
+    if (!fs.existsSync(dirPath)) continue;
+    const resolved = path.resolve(dirPath);
+    const normalized = path.normalize(resolved).toLowerCase();
 
-  function walk(dir) {
-    if (dir.length > 4000) return;
-    let entries;
-    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
-    for (const e of entries) {
-      if (e.name.startsWith(".")) continue;
-      const full = path.join(dir, e.name);
-      const real = path.resolve(full).toLowerCase();
-      if (!real.startsWith(normalized + path.sep) && real !== normalized) continue;
-      if (e.isDirectory()) {
-        walk(full);
-      } else if (e.isFile() && e.name.endsWith(".md")) {
-        let size = 0;
-        try { size = fs.statSync(full).size; } catch { /* skip */ }
-        if (size > MAX_FILE_SIZE) continue;
-        results.push({
-          relativePath: path.relative(wikiPath, full).replace(/\\/g, "/"),
-          size,
-          checksum: null, // not computed for tree view
-        });
+    function walk(dir) {
+      if (dir.length > 4000) return;
+      let entries;
+      try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+      for (const e of entries) {
+        if (e.name.startsWith(".")) continue;
+        const full = path.join(dir, e.name);
+        const real = path.resolve(full).toLowerCase();
+        if (!real.startsWith(normalized + path.sep) && real !== normalized) continue;
+        if (e.isDirectory()) {
+          walk(full);
+        } else if (e.isFile() && e.name.endsWith(".md")) {
+          let size = 0;
+          try { size = fs.statSync(full).size; } catch { /* skip */ }
+          if (size > MAX_FILE_SIZE) continue;
+          const relPath = path.relative(dirPath, full).replace(/\\/g, "/");
+          results.push({ relativePath: dir + "/" + relPath, size, checksum: null });
+        }
       }
     }
+    walk(dirPath);
   }
-  walk(wikiPath);
+
   return results;
 }
 
@@ -313,31 +316,36 @@ function scanVaultPaths(vaultPath) {
  */
 function scanVaultChecksums(vaultPath) {
   const results = [];
-  const wikiPath = path.join(vaultPath, "wiki");
-  if (!fs.existsSync(wikiPath)) return results;
-  const resolved = path.resolve(wikiPath);
-  const normalized = path.normalize(resolved).toLowerCase();
-  function walk(dir) {
-    if (dir.length > 4000) return;
-    let entries;
-    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
-    for (const e of entries) {
-      if (e.name.startsWith(".")) continue;
-      const full = path.join(dir, e.name);
-      const real = path.resolve(full).toLowerCase();
-      if (!real.startsWith(normalized + path.sep) && real !== normalized) continue;
-      if (e.isDirectory()) { walk(full); }
-      else if (e.isFile() && e.name.endsWith(".md")) {
-        let stat;
-        try { stat = fs.statSync(full); } catch { continue; }
-        if (stat.size > MAX_FILE_SIZE) continue;
-        const relPath = path.relative(wikiPath, full).replace(/\\/g, "/");
-        const content = fs.readFileSync(full, "utf8");
-        results.push({ relativePath: relPath, checksum: computeChecksum(content), size: stat.size });
+
+  for (const dir of CONTENT_DIRS) {
+    const dirPath = path.join(vaultPath, dir);
+    if (!fs.existsSync(dirPath)) continue;
+    const resolved = path.resolve(dirPath);
+    const normalized = path.normalize(resolved).toLowerCase();
+
+    function walk(dir) {
+      if (dir.length > 4000) return;
+      let entries;
+      try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+      for (const e of entries) {
+        if (e.name.startsWith(".")) continue;
+        const full = path.join(dir, e.name);
+        const real = path.resolve(full).toLowerCase();
+        if (!real.startsWith(normalized + path.sep) && real !== normalized) continue;
+        if (e.isDirectory()) { walk(full); }
+        else if (e.isFile() && e.name.endsWith(".md")) {
+          let stat;
+          try { stat = fs.statSync(full); } catch { continue; }
+          if (stat.size > MAX_FILE_SIZE) continue;
+          const relPath = path.relative(dirPath, full).replace(/\\/g, "/");
+          const content = fs.readFileSync(full, "utf8");
+          results.push({ relativePath: dir + "/" + relPath, checksum: computeChecksum(content), size: stat.size });
+        }
       }
     }
+    walk(dirPath);
   }
-  walk(wikiPath);
+
   return results;
 }
 
@@ -406,7 +414,6 @@ async function fullExport(vaultPath, selectedPaths) {
   if (!acquireLock()) throw new Error("同步正在进行中，请稍后重试");
   const db = openDb();
   const now = new Date().toISOString();
-  const wikiPath = path.join(vaultPath, "wiki");
 
   const logStmt = db.prepare(
     `INSERT INTO kb_sync_logs (direction, file_path, document_id, status, checksum, detail, created_at)
@@ -416,8 +423,8 @@ async function fullExport(vaultPath, selectedPaths) {
   const summary = { exported: 0, skipped: 0, errors: 0 };
 
   try {
-    // Ensure wiki/ directory exists
-    fs.mkdirSync(wikiPath, { recursive: true });
+    // Ensure content directories exist
+    for (const dir of CONTENT_DIRS) fs.mkdirSync(path.join(vaultPath, dir), { recursive: true });
 
     const docs = db
       .prepare("SELECT * FROM kb_documents WHERE source = 'obsidian'")
@@ -461,8 +468,8 @@ async function fullExport(vaultPath, selectedPaths) {
           continue;
         }
 
-        // Write file
-        const fullPath = path.join(wikiPath, targetPath);
+        // Write file (targetPath includes content dir prefix, e.g. "wiki/file.md")
+        const fullPath = path.join(vaultPath, targetPath);
         fs.mkdirSync(path.dirname(fullPath), { recursive: true });
         fs.writeFileSync(fullPath, fullContent, "utf8");
 
@@ -495,4 +502,4 @@ async function fullExport(vaultPath, selectedPaths) {
   }
 }
 
-module.exports = { scanVault, scanVaultPaths, scanVaultChecksums, buildFileTree, importDocument, fullImport, importFromFiles, fullExport, computeChecksum, acquireLock, releaseLock, isRunning, MAX_FILE_SIZE };
+module.exports = { scanVault, scanVaultPaths, scanVaultChecksums, buildFileTree, importDocument, fullImport, importFromFiles, fullExport, computeChecksum, acquireLock, releaseLock, isRunning, MAX_FILE_SIZE, CONTENT_DIRS };

--- a/server/src/apps/admin/kb/syncHandlers.js
+++ b/server/src/apps/admin/kb/syncHandlers.js
@@ -1,8 +1,15 @@
 ﻿const fs = require("fs");
+const path = require("path");
 const { openDb } = require("../../../db");
 const { nowIso, toInt } = require("../../../utils");
 const syncEngine = require("./syncEngine");
 const kbSync = require("../../../services/kbSync");
+
+const CONTENT_DIRS = syncEngine.CONTENT_DIRS || ['wiki', 'notes'];
+
+function hasContentDir(vaultPath) {
+  return CONTENT_DIRS.some(d => fs.existsSync(path.join(vaultPath, d)));
+}
 
 function parseJsonArray(raw) {
   if (!raw) return [];
@@ -132,10 +139,9 @@ async function triggerExport(req, res) {
     return res.status(409).json({ code: 409, message: "同步正在进行中" });
   }
 
-  // Validate wiki/ exists
-  const wikiPath = require("path").join(config.vault_path, "wiki");
-  if (!require("fs").existsSync(wikiPath)) {
-    return res.status(400).json({ code: 400, message: "仓库路径下未找到 wiki/ 子目录，请先创建或导入数据" });
+  // Validate at least one content directory exists
+  if (!hasContentDir(config.vault_path)) {
+    return res.status(400).json({ code: 400, message: `仓库路径下未找到 ${CONTENT_DIRS.join('/')} 子目录，请先创建或导入数据` });
   }
 
   auditLog(db, req, "trigger_export", config.vault_path, "触发平台→Obsidian导出");
@@ -244,7 +250,7 @@ async function testFilesystem(req, res) {
   }
 
   try {
-    const resolved = require("path").resolve(vaultPath);
+    const resolved = path.resolve(vaultPath);
     if (!fs.existsSync(resolved)) {
       db.prepare(
         "INSERT INTO kb_sync_logs (direction, file_path, status, detail, created_at) VALUES (?, ?, ?, ?, ?)",
@@ -260,17 +266,17 @@ async function testFilesystem(req, res) {
       return res.json({ code: 200, data: { ok: false, message: "路径不是目录", path: resolved } });
     }
 
-    // Only scan the wiki/ subdirectory
-    const wikiPath = require("path").join(resolved, "wiki");
-    if (!fs.existsSync(wikiPath)) {
-      const detail = `路径下未找到 wiki/ 子目录: ${resolved}`;
+    // Validate at least one content directory exists
+    const foundDirs = CONTENT_DIRS.filter(d => fs.existsSync(path.join(resolved, d)));
+    if (foundDirs.length === 0) {
+      const detail = `路径下未找到 ${CONTENT_DIRS.join('/')} 子目录: ${resolved}`;
       db.prepare(
         "INSERT INTO kb_sync_logs (direction, file_path, status, detail, created_at) VALUES (?, ?, ?, ?, ?)",
       ).run("import", vaultPath, "error", detail, now);
-      return res.json({ code: 200, data: { ok: false, message: detail, path: wikiPath } });
+      return res.json({ code: 200, data: { ok: false, message: detail, path: resolved } });
     }
 
-    // Scan for .md files in wiki/
+    // Scan for .md files in all content directories
     let mdCount = 0;
     let totalSize = 0;
     function walk(dir, depth) {
@@ -279,7 +285,7 @@ async function testFilesystem(req, res) {
       try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
       for (const e of entries) {
         if (e.name.startsWith(".")) continue;
-        const full = require("path").join(dir, e.name);
+        const full = path.join(dir, e.name);
         if (e.isDirectory()) { walk(full, depth + 1); }
         else if (e.isFile() && e.name.endsWith(".md")) {
           try {
@@ -289,7 +295,7 @@ async function testFilesystem(req, res) {
         }
       }
     }
-    walk(wikiPath, 0);
+    for (const dir of foundDirs) walk(path.join(resolved, dir), 0);
 
     const detail = `连接成功: 找到 ${mdCount} 个 .md 文件 (${(totalSize / 1024 / 1024).toFixed(1)} MB)`;
     db.prepare(
@@ -318,7 +324,7 @@ function getRemoteFiles(_req, res) {
     let files = [];
 
     if (config && config.vault_path) {
-      const vaultPath = require("path").resolve(config.vault_path);
+      const vaultPath = path.resolve(config.vault_path);
       // Use checksum scan so frontend can compare with synced files
       files = syncEngine.scanVaultChecksums(vaultPath);
     }

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -361,10 +361,7 @@ function migrate(db) {
   }
   try { db.exec(`CREATE INDEX IF NOT EXISTS idx_kb_docs_category ON kb_documents(category)`); } catch { /* ignore */ }
 
-  // Migrate existing obsidian original_path to strip wiki/ prefix
-  try {
-    db.exec(`UPDATE kb_documents SET original_path = SUBSTR(original_path, 6), checksum = NULL, updated_at = datetime('now') WHERE source = 'obsidian' AND original_path LIKE 'wiki/%'`);
-  } catch { /* ignore */ }
+  // original_path now includes content dir prefix (e.g., "wiki/file.md") — see migrate-phase11.js
 
   // Add selected_paths column for sync folder selection
   try { db.exec(`ALTER TABLE kb_sync_config ADD COLUMN selected_paths TEXT NOT NULL DEFAULT '[]'`); } catch { /* already exists */ }

--- a/server/src/migrate-phase11.js
+++ b/server/src/migrate-phase11.js
@@ -43,5 +43,10 @@ module.exports = function migratePhase11(db) {
     }
   } catch(e) { console.log('[P11c]', e.message); }
   
+  // Update existing obsidian original_path values to include "wiki/" prefix
+  try {
+    db.exec("UPDATE kb_documents SET original_path = 'wiki/' || original_path WHERE source = 'obsidian' AND original_path IS NOT NULL AND original_path NOT LIKE 'wiki/%' AND original_path NOT LIKE 'notes/%'");
+  } catch(e) { console.log('[P11d]', e.message); }
+
   console.log('[Phase 11] done');
 };


### PR DESCRIPTION
## Summary

- Extend Obsidian sync to scan both `wiki/` and `notes/` directories in the vault
- File paths are now prefixed with their content dir (e.g., `wiki/file.md`, `notes/file.md`) to avoid collisions
- DB migration prepends `wiki/` to existing `original_path` values
- Removed old migration in `db.js` that was stripping the `wiki/` prefix (conflicted with new approach)

## Test plan

- [ ] Verify sync scans both wiki/ and notes/ directories
- [ ] Verify existing wiki files still work with the wiki/ prefix in original_path
- [ ] Verify test connection reports files from both directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)