### PR TITLE
fix(kb): add direction field to kb_sync_logs insert

### DIFF
--- a/server/src/services/kbSync.js
+++ b/server/src/services/kbSync.js
@@ -718,8 +718,8 @@ async function fullSyncFromOpenWebUI(source) {
   const result = await importFromOpenWebUI();
   
   const db = openDb();
-  db.prepare(`INSERT INTO kb_sync_logs (source_id, sync_type, status, result, created_at)
-               VALUES (?, 'import', ?, ?, ?)`)
+  db.prepare(`INSERT INTO kb_sync_logs (source_id, sync_type, direction, status, result, created_at)
+               VALUES (?, 'import', 'import', ?, ?, ?)`)
     .run(source.id, result.success ? 'success' : 'failed', JSON.stringify(result), nowIso());
   
   return result;


### PR DESCRIPTION
## Summary

`kb_sync_logs.direction` has a NOT NULL constraint. `fullSyncFromOpenWebUI` was inserting without this field, causing `SQLITE_CONSTRAINT_NOTNULL`.

Fix: add `direction = 'import'` to the INSERT statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)