### PR TITLE
feat(kb): add OpenWebUI Notes bidirectional sync

### DIFF
--- a/admin/src/api/kb.ts
+++ b/admin/src/api/kb.ts
@@ -1121,3 +1121,8 @@ export async function apiTriggerOpenWebUIImport(client: AxiosInstance = request)
   const res = await client.post<{ code: number; message: string; data?: unknown }>('/api/v2/admin/kb/sync/openwebui-import')
   return res.data
 }
+
+export async function apiTriggerNotesSync(client: AxiosInstance = request): Promise<{ code: number; message: string; data?: unknown }> {
+  const res = await client.post<{ code: number; message: string; data?: unknown }>('/api/v2/admin/kb/sync/notes-sync')
+  return res.data
+}

--- a/admin/src/views/kb/sync/index.vue
+++ b/admin/src/views/kb/sync/index.vue
@@ -21,6 +21,7 @@ import {
   SettingsOutline,
   CloudOutline,
   FlashOutline,
+  DocumentTextOutline,
 } from '@vicons/ionicons5'
 import PageHeader from '../../../components/common/PageHeader.vue'
 import SyncFileTree from '../../../components/kb/SyncFileTree.vue'
@@ -42,6 +43,7 @@ import {
   apiTestOpenWebUIConnection,
   apiGetOpenWebUISyncProgress,
   apiGetKnowledgeBases,
+  apiTriggerNotesSync,
   type SyncConfig,
   type SyncLogEntry,
   type FileTreeData,
@@ -219,6 +221,31 @@ async function handleSyncToOpenWebUI() {
     openWebUISyncLogs.value.push({ time: new Date().toLocaleTimeString(), message: `同步失败: ${error?.message || '未知错误'}`, type: 'error' })
     message.error('同步启动失败')
     openWebUISyncing.value = false
+  }
+}
+
+// ---- Open WebUI Notes Sync ----
+const notesSyncing = ref(false)
+const notesSyncLogs = ref<Array<{ time: string; message: string; type: 'info' | 'success' | 'error' }>>([])
+const notesLogsCollapsed = ref(false)
+
+async function handleSyncNotes() {
+  if (!openWebUIStatus.value.configured) {
+    message.warning('请先在系统设置中配置 Open WebUI API Key')
+    return
+  }
+  notesSyncing.value = true
+  notesSyncLogs.value = [{ time: new Date().toLocaleTimeString(), message: '开始同步 Open WebUI 笔记...', type: 'info' }]
+  try {
+    await apiTriggerNotesSync()
+    notesSyncLogs.value.push({ time: new Date().toLocaleTimeString(), message: '笔记同步任务已启动', type: 'success' })
+    message.success('笔记同步已启动')
+  } catch (err: unknown) {
+    const error = err as { message?: string }
+    notesSyncLogs.value.push({ time: new Date().toLocaleTimeString(), message: `同步失败: ${error?.message || '未知错误'}`, type: 'error' })
+    message.error('笔记同步启动失败')
+  } finally {
+    notesSyncing.value = false
   }
 }
 
@@ -920,6 +947,69 @@ onMounted(() => {
             <div v-else class="space-y-1.5">
               <div
                 v-for="(log, idx) in openWebUISyncLogs"
+                :key="idx"
+                class="flex items-start gap-2 text-xs"
+              >
+                <span class="text-base-content/30 whitespace-nowrap">{{ log.time }}</span>
+                <span
+                  class="whitespace-nowrap"
+                  :class="{
+                    'text-blue-500': log.type === 'info',
+                    'text-green-500': log.type === 'success',
+                    'text-red-500': log.type === 'error',
+                  }"
+                >{{ log.type === 'info' ? 'ℹ' : log.type === 'success' ? '✓' : '✗' }}</span>
+                <span class="text-base-content/60">{{ log.message }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Open WebUI 笔记同步 -->
+      <div class="bg-base-100 rounded-xl border border-base-content/5 mb-4">
+        <div class="px-4 py-3 border-b border-base-content/5">
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-3">
+              <h3 class="font-medium text-sm">同步 Open WebUI 笔记</h3>
+              <span class="text-xs text-base-content/40">从 /api/v1/notes/ 导入到 vault/notes/</span>
+            </div>
+            <div class="flex items-center gap-2">
+              <NButton
+                size="small"
+                type="primary"
+                :loading="notesSyncing"
+                :disabled="!hasSyncPerm"
+                @click="handleSyncNotes"
+              >
+                <template #icon><DocumentTextOutline class="w-4 h-4" /></template>
+                同步笔记
+              </NButton>
+            </div>
+          </div>
+        </div>
+
+        <!-- Sync logs -->
+        <div
+          class="px-4 py-3 cursor-pointer hover:bg-base-200/30"
+          @click="notesLogsCollapsed = !notesLogsCollapsed"
+        >
+          <div class="flex items-center justify-between">
+            <span class="text-xs text-base-content/60">同步日志</span>
+            <svg class="w-4 h-4 text-base-content/30 transition-transform" :class="notesLogsCollapsed ? '' : 'rotate-180'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </div>
+        </div>
+
+        <div v-if="!notesLogsCollapsed" class="px-4 pb-4">
+          <div class="bg-base-200/50 rounded-lg p-3 max-h-48 overflow-y-auto">
+            <div v-if="notesSyncLogs.length === 0" class="text-xs text-base-content/30 text-center py-4">
+              暂无同步日志
+            </div>
+            <div v-else class="space-y-1.5">
+              <div
+                v-for="(log, idx) in notesSyncLogs"
                 :key="idx"
                 class="flex items-start gap-2 text-xs"
               >

--- a/server/src/apps/admin/kb/syncHandlers.js
+++ b/server/src/apps/admin/kb/syncHandlers.js
@@ -491,9 +491,27 @@ async function triggerOpenWebUIImport(req, res) {
 }
 
 
+// Open WebUI Notes sync (bidirectional: /api/v1/notes/ ↔ notes/ directory)
+async function triggerNotesSync(req, res) {
+  var db = openDb();
+  if (!kbSync.isConfigured()) {
+    return res.status(400).json({code:400,message:'OPEN_WEBUI_API_KEY not configured'});
+  }
+  auditLog(db, req, 'trigger_notes_sync', null, 'Trigger Open WebUI Notes sync');
+  res.status(202).json({code:202,message:'Notes sync started',data:{status:'started'}});
+  try {
+    var result = await kbSync.fullSyncNotes();
+    console.log('[SyncHandler] Open WebUI Notes sync complete:', JSON.stringify(result));
+  } catch(err) {
+    console.error('[SyncHandler] Open WebUI Notes sync failed:', err.message);
+  }
+}
+
+
 module.exports = {
   getSyncConfig, updateSyncConfig, triggerImport, triggerExport,
   listSyncLogs, getSyncStatus, testFilesystem, getRemoteFiles,
   getSyncedFiles, clearSyncedData, getOpenWebUIStatus, triggerOpenWebUISync, triggerOpenWebUIImport,
   testOpenWebUIConnection, getOpenWebUISyncProgress, getKnowledgeBases,
+  triggerNotesSync,
 };

--- a/server/src/apps/admin/kb/syncRouter.js
+++ b/server/src/apps/admin/kb/syncRouter.js
@@ -23,6 +23,7 @@ router.post("/sync/openwebui-sync", jwtAuth, requirePermission("kb:sync"), handl
 router.post("/sync/openwebui-test", jwtAuth, requirePermission("kb:sync"), handlers.testOpenWebUIConnection);
 router.get("/sync/openwebui-progress", jwtAuth, requirePermission("kb:sync"), handlers.getOpenWebUISyncProgress);
 router.post("/sync/openwebui-import", jwtAuth, requirePermission("kb:sync"), handlers.triggerOpenWebUIImport);
+router.post("/sync/notes-sync", jwtAuth, requirePermission("kb:sync"), handlers.triggerNotesSync);
 
 
 module.exports = router;

--- a/server/src/services/kbSync.js
+++ b/server/src/services/kbSync.js
@@ -725,6 +725,112 @@ async function fullSyncFromOpenWebUI(source) {
   return result;
 }
 
+// ---- Open WebUI Notes sync (bidirectional: /api/v1/notes/ ↔ notes/ directory) ----
+
+function getVaultPath() {
+  try {
+    const db = openDb();
+    const config = db.prepare("SELECT vault_path FROM kb_sync_config WHERE id = 1").get();
+    return config?.vault_path || '';
+  } catch { return ''; }
+}
+
+/**
+ * Import: OWUI Notes → local notes/ directory
+ * Reads all notes from /api/v1/notes/ and writes them as .md files.
+ */
+async function importNotesFromOpenWebUI() {
+  const token = getApiKey();
+  const vaultPath = getVaultPath();
+  if (!vaultPath) return { success: false, error: 'vault_path_not_configured' };
+
+  const notesDir = path.join(vaultPath, 'notes');
+  fs.mkdirSync(notesDir, { recursive: true });
+
+  const listRes = await makeRequest('/api/v1/notes/', 'GET', null, token);
+  if (listRes.status < 200 || listRes.status >= 300) {
+    return { success: false, error: 'failed_to_list_notes', detail: listRes.data };
+  }
+
+  const notes = Array.isArray(listRes.data) ? listRes.data : [];
+  let imported = 0, skipped = 0;
+
+  for (const note of notes) {
+    const md = note.data?.content?.md || '';
+    if (!md.trim()) { skipped++; continue; }
+
+    // Sanitize title to a valid filename
+    const safeName = (note.title || `note-${note.id}`)
+      .replace(/[<>:"/\\|?*]/g, '-')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '') || `note-${note.id}`;
+    const filename = safeName + '.md';
+    const filePath = path.join(notesDir, filename);
+
+    // Build frontmatter + body
+    const frontmatter = `---\ntitle: ${note.title || ''}\nowui_id: ${note.id}\ncreated_at: ${note.created_at}\nupdated_at: ${note.updated_at}\n---\n\n`;
+    const fullContent = frontmatter + md;
+
+    // Skip if already exists and unchanged
+    if (fs.existsSync(filePath)) {
+      const existing = fs.readFileSync(filePath, 'utf8');
+      if (existing === fullContent) { skipped++; continue; }
+    }
+
+    fs.writeFileSync(filePath, fullContent, 'utf8');
+    imported++;
+    console.log(`[KBSync] Imported note: ${filename} (${md.length} chars)`);
+  }
+
+  console.log(`[KBSync] importNotesFromOpenWebUI: ${imported} imported, ${skipped} skipped`);
+  return { success: true, imported, skipped };
+}
+
+/**
+ * Export: local notes/ directory → OWUI Notes
+ * NOTE: OWUI Notes API is read-only (all write methods return 405).
+ * This function scans the directory and reports the limitation.
+ */
+async function exportNotesToOpenWebUI() {
+  const vaultPath = getVaultPath();
+  if (!vaultPath) return { success: false, error: 'vault_path_not_configured' };
+
+  const notesDir = path.join(vaultPath, 'notes');
+  if (!fs.existsSync(notesDir)) {
+    return { success: true, exported: 0, skipped: 0, note: 'notes_dir_not_found' };
+  }
+
+  // Scan .md files in notes/ directory
+  const files = fs.readdirSync(notesDir).filter(f => f.endsWith('.md'));
+  if (files.length === 0) return { success: true, exported: 0, skipped: 0 };
+
+  // OWUI Notes API doesn't support writes — log and report
+  console.log(`[KBSync] exportNotesToOpenWebUI: ${files.length} local notes found, but OWUI API is read-only`);
+  return {
+    success: false,
+    exported: 0,
+    skipped: files.length,
+    errors: files.length,
+    note: 'owui_notes_api_read_only',
+  };
+}
+
+/**
+ * Bidirectional sync: import then export
+ */
+async function fullSyncNotes() {
+  console.log('[KBSync] fullSyncNotes starting...');
+
+  const importResult = await importNotesFromOpenWebUI();
+  const exportResult = await exportNotesToOpenWebUI();
+
+  return {
+    import: importResult,
+    export: exportResult,
+  };
+}
+
 module.exports = {
   getApiKey,
   isConfigured,
@@ -737,4 +843,7 @@ module.exports = {
   listKnowledgeBases,
   importFromOpenWebUI,
   fullSyncFromOpenWebUI,
+  importNotesFromOpenWebUI,
+  exportNotesToOpenWebUI,
+  fullSyncNotes,
 };


### PR DESCRIPTION
## Summary

Add a new sync feature between Open WebUI `/api/v1/notes/` and the vault `notes/` directory:

- **Import direction** (OWUI → local): Reads notes from `/api/v1/notes/`, writes each as `.md` file to `notes/` directory with YAML frontmatter (owui_id, title, timestamps)
- **Export direction** (local → OWUI): Scans `notes/` directory — currently limited as OWUI Notes API is read-only (all write methods return 405)
- New admin UI button "同步笔记" under a new card "同步 Open WebUI 笔记"
- New API: `POST /api/v2/admin/kb/sync/notes-sync` (202 async pattern)
- Backend functions: `importNotesFromOpenWebUI()`, `exportNotesToOpenWebUI()`, `fullSyncNotes()`

## Test plan

- [ ] Click "同步笔记" button in admin sync page
- [ ] Verify OWUI notes are written as `.md` files in `vault/notes/` directory
- [ ] Verify repeated sync skips unchanged files

🤖 Generated with [Claude Code](https://claude.com/claude-code)