### PR TITLE
feat(kb): add test button for OpenWebUI Notes connection

### DIFF
--- a/admin/src/api/kb.ts
+++ b/admin/src/api/kb.ts
@@ -1126,3 +1126,23 @@ export async function apiTriggerNotesSync(client: AxiosInstance = request): Prom
   const res = await client.post<{ code: number; message: string; data?: unknown }>('/api/v2/admin/kb/sync/notes-sync')
   return res.data
 }
+
+export interface NotesTestResult {
+  ok: boolean
+  steps: Array<{
+    name: string
+    status: string
+    httpStatus?: number
+    total?: number
+    withContent?: number
+    samples?: Array<{ title: string; contentLength: number }>
+    error?: string
+    detail?: string
+    data?: unknown
+  }>
+}
+
+export async function apiTestNotesConnection(client: AxiosInstance = request): Promise<NotesTestResult> {
+  const res = await client.get<ApiResponse<NotesTestResult>>('/api/v2/admin/kb/sync/notes-test')
+  return res.data.data
+}

--- a/admin/src/views/kb/sync/index.vue
+++ b/admin/src/views/kb/sync/index.vue
@@ -44,6 +44,8 @@ import {
   apiGetOpenWebUISyncProgress,
   apiGetKnowledgeBases,
   apiTriggerNotesSync,
+  apiTestNotesConnection,
+  type NotesTestResult,
   type SyncConfig,
   type SyncLogEntry,
   type FileTreeData,
@@ -246,6 +248,32 @@ async function handleSyncNotes() {
     message.error('笔记同步启动失败')
   } finally {
     notesSyncing.value = false
+  }
+}
+
+const notesTesting = ref(false)
+const notesTestResult = ref<NotesTestResult | null>(null)
+
+async function handleTestNotes() {
+  if (!openWebUIStatus.value.configured) {
+    message.warning('请先在系统设置中配置 Open WebUI API Key')
+    return
+  }
+  notesTesting.value = true
+  notesTestResult.value = null
+  try {
+    const result = await apiTestNotesConnection()
+    notesTestResult.value = result
+    if (result.ok) {
+      message.success('Open WebUI 笔记连接测试通过')
+    } else {
+      message.error('连接测试失败')
+    }
+  } catch (err: unknown) {
+    const error = err as { message?: string }
+    message.error(`测试失败: ${error?.message || '未知错误'}`)
+  } finally {
+    notesTesting.value = false
   }
 }
 
@@ -977,6 +1005,16 @@ onMounted(() => {
             <div class="flex items-center gap-2">
               <NButton
                 size="small"
+                secondary
+                :loading="notesTesting"
+                :disabled="!hasSyncPerm"
+                @click="handleTestNotes"
+              >
+                <template #icon><FlashOutline class="w-4 h-4" /></template>
+                测试连接
+              </NButton>
+              <NButton
+                size="small"
                 type="primary"
                 :loading="notesSyncing"
                 :disabled="!hasSyncPerm"
@@ -985,6 +1023,29 @@ onMounted(() => {
                 <template #icon><DocumentTextOutline class="w-4 h-4" /></template>
                 同步笔记
               </NButton>
+            </div>
+          </div>
+        </div>
+
+        <!-- Test result -->
+        <div v-if="notesTestResult" class="px-4 py-3 border-b border-base-content/5">
+          <div class="text-xs font-medium mb-2" :class="notesTestResult.ok ? 'text-green-500' : 'text-red-500'">
+            {{ notesTestResult.ok ? '连接测试通过' : '连接测试失败' }}
+          </div>
+          <div class="space-y-1">
+            <div v-for="step in notesTestResult.steps" :key="step.name" class="flex items-center gap-2 text-xs">
+              <span
+                class="inline-block w-1.5 h-1.5 rounded-full"
+                :class="step.status === 'ok' ? 'bg-green-500' : step.status === 'warn' ? 'bg-amber-500' : 'bg-red-500'"
+              />
+              <span class="text-base-content/60">{{ step.name }}</span>
+              <span v-if="step.httpStatus" class="text-base-content/30">(HTTP {{ step.httpStatus }})</span>
+              <span v-if="step.total !== undefined" class="text-base-content/60">共 {{ step.total }} 条, 有内容 {{ step.withContent }} 条</span>
+              <span v-if="step.error" class="text-red-400">{{ step.error }}</span>
+              <span v-if="step.detail && step.total === undefined" class="text-base-content/40">{{ step.detail }}</span>
+            </div>
+            <div v-if="notesTestResult.steps.find(s => s.samples)" class="mt-1 text-[10px] text-base-content/30">
+              示例: {{ notesTestResult.steps.find(s => s.samples)?.samples?.map(s => s.title + '(' + s.contentLength + '字)').join(', ') }}
             </div>
           </div>
         </div>

--- a/server/src/apps/admin/kb/syncHandlers.js
+++ b/server/src/apps/admin/kb/syncHandlers.js
@@ -507,11 +507,21 @@ async function triggerNotesSync(req, res) {
   }
 }
 
+// Test Open WebUI Notes connection
+async function testNotesConnection(req, res) {
+  try {
+    var result = await kbSync.testNotesConnection();
+    res.json({ code: 200, data: result });
+  } catch (err) {
+    res.status(500).json({ code: 500, message: err.message });
+  }
+}
+
 
 module.exports = {
   getSyncConfig, updateSyncConfig, triggerImport, triggerExport,
   listSyncLogs, getSyncStatus, testFilesystem, getRemoteFiles,
   getSyncedFiles, clearSyncedData, getOpenWebUIStatus, triggerOpenWebUISync, triggerOpenWebUIImport,
   testOpenWebUIConnection, getOpenWebUISyncProgress, getKnowledgeBases,
-  triggerNotesSync,
+  triggerNotesSync, testNotesConnection,
 };

--- a/server/src/apps/admin/kb/syncRouter.js
+++ b/server/src/apps/admin/kb/syncRouter.js
@@ -24,6 +24,7 @@ router.post("/sync/openwebui-test", jwtAuth, requirePermission("kb:sync"), handl
 router.get("/sync/openwebui-progress", jwtAuth, requirePermission("kb:sync"), handlers.getOpenWebUISyncProgress);
 router.post("/sync/openwebui-import", jwtAuth, requirePermission("kb:sync"), handlers.triggerOpenWebUIImport);
 router.post("/sync/notes-sync", jwtAuth, requirePermission("kb:sync"), handlers.triggerNotesSync);
+router.get("/sync/notes-test", jwtAuth, requirePermission("kb:sync"), handlers.testNotesConnection);
 
 
 module.exports = router;

--- a/server/src/services/kbSync.js
+++ b/server/src/services/kbSync.js
@@ -831,6 +831,70 @@ async function fullSyncNotes() {
   };
 }
 
+/**
+ * Test connection to OWUI Notes API
+ */
+async function testNotesConnection() {
+  const token = getApiKey();
+  if (!token) return { ok: false, error: 'api_key_not_configured' };
+
+  const vaultPath = getVaultPath();
+
+  const results = { steps: [], ok: false };
+
+  // Step 1: check vault path
+  results.steps.push({
+    name: 'vault_path',
+    status: vaultPath ? 'ok' : 'fail',
+    vaultPath: vaultPath || '(not configured)',
+  });
+  if (vaultPath) {
+    const notesDirExists = require('fs').existsSync(require('path').join(vaultPath, 'notes'));
+    results.steps.push({
+      name: 'notes_dir',
+      status: notesDirExists ? 'ok' : 'warn',
+      detail: notesDirExists ? 'notes/ 目录存在' : 'notes/ 目录不存在（将自动创建）',
+    });
+  }
+
+  // Step 2: call the notes API
+  try {
+    const listRes = await makeRequest('/api/v1/notes/', 'GET', null, token);
+    const httpOk = listRes.status >= 200 && listRes.status < 300;
+    results.steps.push({
+      name: 'notes_api',
+      status: httpOk ? 'ok' : 'fail',
+      httpStatus: listRes.status,
+      detail: httpOk ? '连接成功' : 'API 返回错误',
+      data: !httpOk ? listRes.data : undefined,
+    });
+
+    if (httpOk) {
+      const notes = Array.isArray(listRes.data) ? listRes.data : [];
+      const withContent = notes.filter(n => n.data?.content?.md?.trim());
+      results.steps.push({
+        name: 'notes_count',
+        status: 'ok',
+        total: notes.length,
+        withContent: withContent.length,
+        samples: withContent.slice(0, 3).map(n => ({
+          title: n.title,
+          contentLength: (n.data?.content?.md || '').length,
+        })),
+      });
+      results.ok = true;
+    }
+  } catch (err) {
+    results.steps.push({
+      name: 'notes_api',
+      status: 'fail',
+      error: err.message,
+    });
+  }
+
+  return results;
+}
+
 module.exports = {
   getApiKey,
   isConfigured,
@@ -846,4 +910,5 @@ module.exports = {
   importNotesFromOpenWebUI,
   exportNotesToOpenWebUI,
   fullSyncNotes,
+  testNotesConnection,
 };


### PR DESCRIPTION
## Summary

Add a diagnostic test button for the OWUI Notes sync:
- Backend: `testNotesConnection()` — tests vault path, notes dir, and `/api/v1/notes/` API
- API: `GET /api/v2/admin/kb/sync/notes-test`
- Frontend: "测试连接" button in the "同步 Open WebUI 笔记" card, shows step-by-step results

🤖 Generated with [Claude Code](https://claude.com/claude-code)