### PR TITLE
fix(kb): make notes sync synchronous to show results

### DIFF
--- a/admin/src/views/kb/sync/index.vue
+++ b/admin/src/views/kb/sync/index.vue
@@ -239,13 +239,20 @@ async function handleSyncNotes() {
   notesSyncing.value = true
   notesSyncLogs.value = [{ time: new Date().toLocaleTimeString(), message: '开始同步 Open WebUI 笔记...', type: 'info' }]
   try {
-    await apiTriggerNotesSync()
-    notesSyncLogs.value.push({ time: new Date().toLocaleTimeString(), message: '笔记同步任务已启动', type: 'success' })
-    message.success('笔记同步已启动')
+    const res = await apiTriggerNotesSync()
+    const data = res.data as { import?: { imported?: number; skipped?: number }; export?: { exported?: number } } | undefined
+    const imported = data?.import?.imported ?? 0
+    const skipped = data?.import?.skipped ?? 0
+    notesSyncLogs.value.push({
+      time: new Date().toLocaleTimeString(),
+      message: `同步完成: 导入 ${imported} 条, 跳过 ${skipped} 条`,
+      type: 'success',
+    })
+    message.success(`笔记同步完成: 导入 ${imported} 条`)
   } catch (err: unknown) {
     const error = err as { message?: string }
     notesSyncLogs.value.push({ time: new Date().toLocaleTimeString(), message: `同步失败: ${error?.message || '未知错误'}`, type: 'error' })
-    message.error('笔记同步启动失败')
+    message.error('笔记同步失败')
   } finally {
     notesSyncing.value = false
   }

--- a/server/src/apps/admin/kb/syncHandlers.js
+++ b/server/src/apps/admin/kb/syncHandlers.js
@@ -498,12 +498,13 @@ async function triggerNotesSync(req, res) {
     return res.status(400).json({code:400,message:'OPEN_WEBUI_API_KEY not configured'});
   }
   auditLog(db, req, 'trigger_notes_sync', null, 'Trigger Open WebUI Notes sync');
-  res.status(202).json({code:202,message:'Notes sync started',data:{status:'started'}});
   try {
     var result = await kbSync.fullSyncNotes();
     console.log('[SyncHandler] Open WebUI Notes sync complete:', JSON.stringify(result));
+    res.json({ code: 200, message: 'Notes sync complete', data: result });
   } catch(err) {
     console.error('[SyncHandler] Open WebUI Notes sync failed:', err.message);
+    res.status(500).json({ code: 500, message: err.message });
   }
 }
 


### PR DESCRIPTION
Changed from 202 async to synchronous response. Frontend now waits for completion and displays actual import count.