### PR TITLE
fix(kb): add sync_type to SyncLogEntry type

### DIFF
--- a/admin/src/api/kb.ts
+++ b/admin/src/api/kb.ts
@@ -473,6 +473,7 @@ export interface SyncLogEntry {
   status: 'success' | 'skipped' | 'conflict' | 'error'
   checksum: string | null
   detail: string | null
+  sync_type: string | null
   created_at: string
 }
 


### PR DESCRIPTION
Missing sync_type field in SyncLogEntry interface caused vue-tsc build failure.