### PR TITLE
feat(publish-api): add API key auth for blog and KB publish endpoints

### DIFF
--- a/admin/src/views/settings/index.vue
+++ b/admin/src/views/settings/index.vue
@@ -10,6 +10,8 @@ const iotAppId = ref('')
 const iotAppSecret = ref('')
 const iotSyncEnabled = ref(true)
 const iotSyncInterval = ref(60)
+const publishApiKey = ref('')
+const publishApiKeyEnabled = ref(true)
 const loading = ref(false)
 const saving = ref(false)
 const message = ref('')
@@ -28,6 +30,8 @@ async function loadSettings() {
       iotAppSecret.value = data.data?.iot_app_secret || ''
       iotSyncEnabled.value = data.data?.iot_sync_enabled !== 0
       iotSyncInterval.value = data.data?.iot_sync_interval || 60
+      publishApiKey.value = data.data?.publish_api_key || ''
+      publishApiKeyEnabled.value = data.data?.publish_api_key_enabled !== 0
     }
   } catch (err) {
     console.error('Failed to load settings:', err)
@@ -51,6 +55,8 @@ async function saveSettings() {
         iot_app_secret: iotAppSecret.value,
         iot_sync_enabled: iotSyncEnabled.value,
         iot_sync_interval: iotSyncInterval.value,
+        publish_api_key: publishApiKey.value,
+        publish_api_key_enabled: publishApiKeyEnabled.value,
       }),
     })
     const data = await res.json()
@@ -77,6 +83,15 @@ function testConnection() {
     return
   }
   window.open(url, '_blank')
+}
+
+function generateNewKey() {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  let key = ''
+  for (let i = 0; i < 32; i++) {
+    key += chars.charAt(Math.floor(Math.random() * chars.length))
+  }
+  publishApiKey.value = key
 }
 
 onMounted(() => {
@@ -193,6 +208,49 @@ onMounted(() => {
           </template>
           <div class="text-sm text-gray-400">
             物联网卡平台接口凭证，用于同步卡片数据、查询余额、启用/禁用卡片等操作。
+          </div>
+        </NFormItem>
+
+        <NSpace>
+          <NButton type="primary" :loading="saving" @click="saveSettings">
+            保存设置
+          </NButton>
+        </NSpace>
+      </NForm>
+    </NCard>
+
+    <NCard class="max-w-2xl">
+      <NForm label-placement="left" label-width="160px">
+        <div class="text-sm font-medium mb-2 text-gray-500">发布 API</div>
+        <NFormItem label="启用 API Key">
+          <NSwitch v-model:value="publishApiKeyEnabled" :loading="loading" />
+          <span class="text-xs text-gray-400 ml-2">启用后，外部应用可通过 API Key 访问发布接口</span>
+        </NFormItem>
+
+        <NFormItem label="API Key">
+          <NInput
+            v-model:value="publishApiKey"
+            placeholder="留空则保持当前密钥"
+            type="password"
+            show-password-on="click"
+            :loading="loading"
+          />
+          <template #feedback>
+            <div class="text-xs text-gray-400 mt-1">
+              用于外部系统调用发布接口。
+              <NButton size="tiny" @click="generateNewKey">生成新密钥</NButton>
+            </div>
+          </template>
+        </NFormItem>
+
+        <NFormItem>
+          <template #label>
+            <span class="text-gray-500">接口地址</span>
+          </template>
+          <div class="text-sm text-gray-500">
+            <div>发布博客文章：<code class="bg-gray-100 px-1 rounded">POST /api/v2/publish/blog</code></div>
+            <div>发布知识库文档：<code class="bg-gray-100 px-1 rounded">POST /api/v2/publish/kb</code></div>
+            <div class="text-xs text-gray-400 mt-1">认证方式：Header <code>X-API-Key</code> 或 Query <code>api_key</code></div>
           </div>
         </NFormItem>
 

--- a/server/src/apps/admin/kb/publishApiHandlers.js
+++ b/server/src/apps/admin/kb/publishApiHandlers.js
@@ -1,0 +1,131 @@
+const { openDb } = require("../../../db");
+const { nowIso, normalizeSlug, splitTags } = require("../../../utils");
+
+function ensureUniqueSlug(db, baseSlug, table, column = "slug") {
+  let slug = baseSlug;
+  let counter = 0;
+  while (true) {
+    const existing = db.prepare(`SELECT id FROM ${table} WHERE ${column} = ?`).get(slug);
+    if (!existing) break;
+    counter++;
+    slug = `${baseSlug}-${counter}`;
+  }
+  return slug;
+}
+
+function publishBlogPost(req, res) {
+  const { title, slug: inputSlug, excerpt, coverImageUrl, contentMarkdown, tags, categories, status } = req.body;
+
+  if (!title || !contentMarkdown) {
+    return res.status(400).json({ error: "title and contentMarkdown are required" });
+  }
+
+  const db = openDb();
+  const now = nowIso();
+
+  const baseSlug = inputSlug ? normalizeSlug(inputSlug) : normalizeSlug(title);
+  const slug = ensureUniqueSlug(db, baseSlug, "posts");
+
+  const wordCount = contentMarkdown.split(/\s+/).filter(Boolean).length;
+  const contentHtml = contentMarkdown;
+
+  const post = db.prepare(`
+    INSERT INTO posts (title, slug, excerpt, coverImageUrl, contentMarkdown, contentHtml, status, publishedAt, createdAt, updatedAt)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    title,
+    slug,
+    excerpt || "",
+    coverImageUrl || "",
+    contentMarkdown,
+    contentHtml,
+    status === "published" ? "published" : "draft",
+    status === "published" ? now : null,
+    now,
+    now
+  );
+
+  const postId = post.lastInsertRowid;
+
+  if (tags && Array.isArray(tags) && tags.length > 0) {
+    const tagIds = [];
+    for (const tagName of tags) {
+      let tag = db.prepare("SELECT id FROM tags WHERE name = ?").get(tagName);
+      if (!tag) {
+        const tagSlug = normalizeSlug(tagName);
+        const result = db.prepare("INSERT INTO tags (name, slug, createdAt) VALUES (?, ?, ?)").run(tagName, tagSlug, now);
+        tag = { id: result.lastInsertRowid };
+      }
+      tagIds.push(tag.id);
+    }
+    for (const tagId of tagIds) {
+      db.prepare("INSERT OR IGNORE INTO post_tags (postId, tagId) VALUES (?, ?)").run(postId, tagId);
+    }
+  }
+
+  if (categories && Array.isArray(categories) && categories.length > 0) {
+    const catIds = [];
+    for (const catName of categories) {
+      let cat = db.prepare("SELECT id FROM categories WHERE name = ?").get(catName);
+      if (!cat) {
+        const catSlug = normalizeSlug(catName);
+        const result = db.prepare("INSERT INTO categories (name, slug, createdAt) VALUES (?, ?, ?)").run(catName, catSlug, now);
+        cat = { id: result.lastInsertRowid };
+      }
+      catIds.push(cat.id);
+    }
+    for (const catId of catIds) {
+      db.prepare("INSERT OR IGNORE INTO post_categories (postId, categoryId) VALUES (?, ?)").run(postId, catId);
+    }
+  }
+
+  res.status(201).json({
+    code: 201,
+    message: "success",
+    data: { postId, slug, wordCount },
+  });
+}
+
+function publishKbDocument(req, res) {
+  const { title, slug: inputSlug, excerpt, contentMarkdown, contentHtml, category, doc_type, tags, status } = req.body;
+
+  if (!title || !contentMarkdown) {
+    return res.status(400).json({ error: "title and contentMarkdown are required" });
+  }
+
+  const db = openDb();
+  const now = nowIso();
+
+  const baseSlug = inputSlug ? normalizeSlug(inputSlug) : normalizeSlug(title);
+  const slug = ensureUniqueSlug(db, baseSlug, "kb_documents");
+
+  const wordCount = contentMarkdown.split(/\s+/).filter(Boolean).length;
+
+  const doc = db.prepare(`
+    INSERT INTO kb_documents (title, slug, excerpt, content_markdown, content_html, source, category, doc_type, status, word_count, tags, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, 'api', ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    title,
+    slug,
+    excerpt || "",
+    contentMarkdown,
+    contentHtml || contentMarkdown,
+    category || "",
+    doc_type || "concept",
+    status === "archived" ? "archived" : "active",
+    wordCount,
+    JSON.stringify(tags || []),
+    now,
+    now
+  );
+
+  const documentId = doc.lastInsertRowid;
+
+  res.status(201).json({
+    code: 201,
+    message: "success",
+    data: { documentId, slug, wordCount },
+  });
+}
+
+module.exports = { publishBlogPost, publishKbDocument };

--- a/server/src/apps/admin/settings/settingsRouter.js
+++ b/server/src/apps/admin/settings/settingsRouter.js
@@ -19,6 +19,8 @@ router.get("/", (req, res) => {
       iot_app_secret: "",
       iot_sync_enabled: 1,
       iot_sync_interval: 60,
+      publish_api_key: "",
+      publish_api_key_enabled: 1,
     },
   });
 });
@@ -33,13 +35,15 @@ router.put("/", (req, res) => {
     iot_app_secret,
     iot_sync_enabled,
     iot_sync_interval,
+    publish_api_key,
+    publish_api_key_enabled,
   } = req.body;
   const db = openDb();
   const now = nowIso();
 
   db.prepare(
-    `INSERT INTO system_settings (id, open_webui_url, open_webui_api_key, iot_api_base_url, iot_app_id, iot_app_secret, iot_sync_enabled, iot_sync_interval, created_at, updated_at)
-     VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `INSERT INTO system_settings (id, open_webui_url, open_webui_api_key, iot_api_base_url, iot_app_id, iot_app_secret, iot_sync_enabled, iot_sync_interval, publish_api_key, publish_api_key_enabled, created_at, updated_at)
+     VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(id) DO UPDATE SET
        open_webui_url = excluded.open_webui_url,
        open_webui_api_key = excluded.open_webui_api_key,
@@ -48,6 +52,8 @@ router.put("/", (req, res) => {
        iot_app_secret = excluded.iot_app_secret,
        iot_sync_enabled = excluded.iot_sync_enabled,
        iot_sync_interval = excluded.iot_sync_interval,
+       publish_api_key = excluded.publish_api_key,
+       publish_api_key_enabled = excluded.publish_api_key_enabled,
        updated_at = excluded.updated_at`
   ).run(
     open_webui_url || "",
@@ -57,6 +63,8 @@ router.put("/", (req, res) => {
     iot_app_secret || "",
     iot_sync_enabled !== undefined ? (iot_sync_enabled ? 1 : 0) : 1,
     iot_sync_interval !== undefined ? Math.max(5, Math.min(1440, parseInt(iot_sync_interval, 10) || 60)) : 60,
+    publish_api_key !== undefined ? publish_api_key : "",
+    publish_api_key_enabled !== undefined ? (publish_api_key_enabled ? 1 : 0) : 1,
     now,
     now
   );
@@ -76,6 +84,8 @@ router.put("/", (req, res) => {
       iot_app_secret: iot_app_secret || "",
       iot_sync_enabled: iot_sync_enabled !== undefined ? !!iot_sync_enabled : true,
       iot_sync_interval: iot_sync_interval !== undefined ? parseInt(iot_sync_interval, 10) || 60 : 60,
+      publish_api_key: publish_api_key !== undefined ? publish_api_key : "",
+      publish_api_key_enabled: publish_api_key_enabled !== undefined ? !!publish_api_key_enabled : true,
     },
   });
 });

--- a/server/src/apps/publishApi.js
+++ b/server/src/apps/publishApi.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const requirePublishApiKey = require("../middleware/publishApiKey");
+const { publishBlogPost, publishKbDocument } = require("./admin/kb/publishApiHandlers");
+
+const app = express.Router();
+
+app.use(express.json({ limit: "2mb" }));
+
+app.post("/publish/blog", requirePublishApiKey, publishBlogPost);
+app.post("/publish/kb", requirePublishApiKey, publishKbDocument);
+
+module.exports = app;

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -513,6 +513,10 @@ function migrate(db) {
   try { db.exec(`ALTER TABLE system_settings ADD COLUMN iot_sync_interval INTEGER NOT NULL DEFAULT 60`); } catch { /* exists */ }
   db.prepare(`INSERT OR IGNORE INTO system_settings (id, open_webui_url, open_webui_api_key, iot_api_base_url, iot_app_id, iot_app_secret, iot_sync_enabled, iot_sync_interval, created_at, updated_at) VALUES (1, '', '', '', '', '', 1, 60, datetime('now'), datetime('now'))`).run();
 
+  // Phase 11: Publish API key
+  try { db.exec(`ALTER TABLE system_settings ADD COLUMN publish_api_key TEXT NOT NULL DEFAULT ''`); } catch { /* exists */ }
+  try { db.exec(`ALTER TABLE system_settings ADD COLUMN publish_api_key_enabled INTEGER NOT NULL DEFAULT 1`); } catch { /* exists */ }
+
   // Seed default prompt templates
   const tmplCount = db.prepare("SELECT COUNT(*) AS c FROM kb_prompt_templates").get().c;
   if (tmplCount === 0) {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -59,6 +59,7 @@ ensureRbacSeed(db, {
 
 const frontApp = require("./apps/frontApp");
 const adminApp = require("./apps/adminApp");
+const publishApi = require("./apps/publishApi");
 const openWebUILauncher = require("./openwebui/launcher");
 
 const FRONT_PORT = parseInt(process.env.PORT, 10) || 8787;
@@ -71,6 +72,9 @@ openWebUILauncher.start().then((info) => {
 }).catch((err) => {
   console.error("[OpenWebUI] Launcher failed:", err.message);
 });
+
+// Mount publish API on frontApp at /api/v2/publish/*
+frontApp.use("/api/v2/publish", publishApi);
 
 frontApp.listen(FRONT_PORT, BIND_HOST, () => {
   console.log(`Front blog : http://${BIND_HOST}:${FRONT_PORT}`);

--- a/server/src/middleware/publishApiKey.js
+++ b/server/src/middleware/publishApiKey.js
@@ -1,0 +1,42 @@
+const crypto = require("node:crypto");
+const { openDb } = require("../db");
+
+function getPublishApiKey() {
+  const db = openDb();
+  const settings = db.prepare("SELECT publish_api_key, publish_api_key_enabled FROM system_settings WHERE id = 1").get();
+  return {
+    key: settings?.publish_api_key || "",
+    enabled: settings?.publish_api_key_enabled === 1,
+  };
+}
+
+function requirePublishApiKey(req, res, next) {
+  const apiKey = req.headers["x-api-key"] || req.query["api_key"];
+  const { key: storedKey, enabled } = getPublishApiKey();
+
+  if (!storedKey) {
+    return res.status(503).json({ error: "api_key_not_configured" });
+  }
+
+  if (!enabled) {
+    return res.status(503).json({ error: "api_key_disabled" });
+  }
+
+  if (!apiKey) {
+    return res.status(401).json({ error: "invalid_api_key" });
+  }
+
+  try {
+    const a = Buffer.from(apiKey, "utf8");
+    const b = Buffer.from(storedKey, "utf8");
+    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+      return res.status(401).json({ error: "invalid_api_key" });
+    }
+  } catch {
+    return res.status(401).json({ error: "invalid_api_key" });
+  }
+
+  next();
+}
+
+module.exports = requirePublishApiKey;


### PR DESCRIPTION
## Summary
- Add configurable API key authentication for external publish endpoints
- `POST /api/v2/publish/blog` - Publish documents to blog
- `POST /api/v2/publish/kb` - Publish documents to knowledge base
- API key managed via admin settings UI with enable/disable toggle
- Slug conflicts auto-resolved with numeric suffix

## Test plan
- [ ] Start server and verify DB migration runs
- [ ] Configure API key in admin settings
- [ ] Test blog publish with curl
- [ ] Test KB publish with curl
- [ ] Verify slug conflict handling
- [ ] Verify auth errors (invalid key, missing key, disabled key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)