### PR TITLE
fix(kb): use js-yaml for consistent YAML parsing

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.4",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.12.2",
         "@vitejs/plugin-vue": "^6.0.6",
         "@vue/tsconfig": "^0.9.1",
@@ -1383,6 +1384,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/lodash": {
       "version": "4.17.24",

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -15,6 +15,7 @@
         "echarts": "^6.0.0",
         "fabric": "^7.3.1",
         "highlight.js": "^11.11.1",
+        "js-yaml": "^4.1.1",
         "marked": "^18.0.3",
         "naive-ui": "^2.44.1",
         "pinia": "^3.0.4",
@@ -1691,6 +1692,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/ast-kit": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
@@ -2593,6 +2600,18 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/jsdom": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -16,6 +16,7 @@
     "echarts": "^6.0.0",
     "fabric": "^7.3.1",
     "highlight.js": "^11.11.1",
+    "js-yaml": "^4.1.1",
     "marked": "^18.0.3",
     "naive-ui": "^2.44.1",
     "pinia": "^3.0.4",

--- a/admin/package.json
+++ b/admin/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.4",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.12.2",
     "@vitejs/plugin-vue": "^6.0.6",
     "@vue/tsconfig": "^0.9.1",

--- a/admin/src/views/kb/documents/edit.vue
+++ b/admin/src/views/kb/documents/edit.vue
@@ -113,7 +113,7 @@ function parseYamlFrontMatter(content: string): { attributes: Record<string, unk
   const body = content.slice(match[0].length)
 
   try {
-    const data = yaml.load(yamlStr)
+    const data = yaml.load(yamlStr) as Record<string, unknown>
     return {
       attributes: (data && typeof data === 'object' && !Array.isArray(data)) ? data : {},
       body,

--- a/admin/src/views/kb/documents/edit.vue
+++ b/admin/src/views/kb/documents/edit.vue
@@ -2,6 +2,7 @@
 import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router'
 import axios from 'axios'
+import yaml from 'js-yaml'
 import {
   NButton,
   NForm,
@@ -100,34 +101,26 @@ const formRules = computed<FormRules>(() => ({
 // ---- YAML front matter helpers ----
 
 /**
- * Parse YAML front matter from markdown content (frontend lightweight parser).
+ * Parse YAML front matter from markdown content using js-yaml.
  */
 function parseYamlFrontMatter(content: string): { attributes: Record<string, unknown>; body: string } {
+  if (typeof content !== 'string') return { attributes: {}, body: '' }
+
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/)
   if (!match) return { attributes: {}, body: content }
 
   const yamlStr = match[1]
   const body = content.slice(match[0].length)
-  const attrs: Record<string, unknown> = {}
 
-  for (const line of yamlStr.split('\n')) {
-    const colonIdx = line.indexOf(':')
-    if (colonIdx === -1) continue
-    const key = line.slice(0, colonIdx).trim()
-    let val: unknown = line.slice(colonIdx + 1).trim()
-
-    if (typeof val === 'string' && val.startsWith('[') && val.endsWith(']')) {
-      val = val.slice(1, -1).split(',').map(s => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean)
-    } else if (typeof val === 'string' && (val.startsWith('"') && val.endsWith('"') || val.startsWith("'") && val.endsWith("'"))) {
-      val = val.slice(1, -1)
-    } else if (typeof val === 'string' && val.length === 0) {
-      continue
+  try {
+    const data = yaml.load(yamlStr)
+    return {
+      attributes: (data && typeof data === 'object' && !Array.isArray(data)) ? data : {},
+      body,
     }
-
-    attrs[key] = val
+  } catch {
+    return { attributes: {}, body: content }
   }
-
-  return { attributes: attrs, body }
 }
 
 /**
@@ -135,7 +128,7 @@ function parseYamlFrontMatter(content: string): { attributes: Record<string, unk
  * Writes all keys, with known keys ordered first.
  */
 function buildYamlFrontMatter(attrs: Record<string, unknown>): string {
-  const knownKeys = ['title', 'type', 'tags', 'connections', 'sources', 'last_updated', 'status']
+  const knownKeys = ['title', 'type', 'tags', 'connections', 'sources', 'excerpt', 'description', 'category', 'last_updated', 'status']
   const written = new Set<string>()
   const lines: string[] = []
 
@@ -193,7 +186,7 @@ async function loadDocument() {
     form.review_status = yaml.status as string ?? detail.review_status ?? ''
 
     // Preserve any extra YAML fields not in the known schema
-    const knownKeys = new Set(['title', 'type', 'tags', 'connections', 'sources', 'last_updated', 'status', 'category'])
+    const knownKeys = new Set(['title', 'type', 'tags', 'connections', 'sources', 'excerpt', 'description', 'category', 'last_updated', 'status'])
     for (const k of Object.keys(extraYamlFields)) delete extraYamlFields[k]
     for (const k of Object.keys(yaml)) {
       if (!knownKeys.has(k)) {
@@ -236,6 +229,9 @@ async function doSave(): Promise<boolean> {
       tags: form.tags,
       connections: form.connections,
       sources: form.sources,
+      excerpt: form.excerpt || undefined,
+      description: form.excerpt || undefined,
+      category: form.category || undefined,
       last_updated: form.doc_date || undefined,
       status: form.review_status || undefined,
       ...extraYamlFields,


### PR DESCRIPTION
## Summary
- Replace hand-written regex YAML parser with js-yaml library on frontend
- Correctly parses multi-line YAML arrays like `connections:\n  - Doc 1\n  - Doc 2`
- Add excerpt, description, category to known keys in buildYamlFrontMatter

## Problem
The old regex parser only understood `[item1, item2]` format. Obsidian exports multi-line YAML which caused field loss during sync cycles.

## Test plan
- [ ] Edit a KB doc with connections/sources, save and verify
- [ ] Re-export to vault and verify multi-line YAML format is preserved
- [ ] Re-import and verify fields are correctly loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)