### PR TITLE
fix(kb): use js-yaml.dump for round-trip safety and fix graph connections

### DIFF
--- a/admin/src/views/kb/documents/edit.vue
+++ b/admin/src/views/kb/documents/edit.vue
@@ -124,45 +124,42 @@ function parseYamlFrontMatter(content: string): { attributes: Record<string, unk
 }
 
 /**
- * Build YAML front matter string from attributes object.
- * Writes all keys, with known keys ordered first.
+ * Build YAML front matter string from attributes object using js-yaml.dump.
+ * Known keys are written first; extra keys follow in their original order.
  */
 function buildYamlFrontMatter(attrs: Record<string, unknown>): string {
   const knownKeys = ['title', 'type', 'tags', 'connections', 'sources', 'excerpt', 'description', 'category', 'last_updated', 'status']
+
+  // Build ordered attrs: known keys first, then extra keys
+  const orderedAttrs: Record<string, unknown> = {}
   const written = new Set<string>()
-  const lines: string[] = []
 
   for (const k of knownKeys) {
     const v = attrs[k]
     if (v === undefined || v === null || v === '') continue
-    written.add(k)
     if (Array.isArray(v) && v.length === 0) continue
-    if (Array.isArray(v)) {
-      const items = v.map((i: unknown) => typeof i === 'string' && i.includes(' ') ? `"${i}"` : String(i)).join(', ')
-      lines.push(`${k}: [${items}]`)
-    } else if (typeof v === 'string' && /[:\-\[\]]/.test(v)) {
-      lines.push(`${k}: "${v}"`)
-    } else {
-      lines.push(`${k}: ${v}`)
-    }
+    orderedAttrs[k] = v
+    written.add(k)
   }
 
-  // Write extra keys (preserves unknown YAML fields)
   for (const k of Object.keys(attrs)) {
     if (written.has(k)) continue
     const v = attrs[k]
     if (v === undefined || v === null || v === '') continue
     if (Array.isArray(v) && v.length === 0) continue
-    if (Array.isArray(v)) {
-      const items = v.map((i: unknown) => typeof i === 'string' && i.includes(' ') ? `"${i}"` : String(i)).join(', ')
-      lines.push(`${k}: [${items}]`)
-    } else {
-      lines.push(`${k}: ${v}`)
-    }
+    orderedAttrs[k] = v
   }
 
-  if (lines.length === 0) return ''
-  return `---\n${lines.join('\n')}\n---\n`
+  if (Object.keys(orderedAttrs).length === 0) return ''
+
+  const yamlStr = yaml.dump(orderedAttrs, {
+    lineWidth: -1,
+    noRefs: true,
+    quotingType: '"',
+    forceQuotes: false,
+  })
+
+  return `---\n${yamlStr}---\n`
 }
 
 async function loadDocument() {
@@ -230,7 +227,6 @@ async function doSave(): Promise<boolean> {
       connections: form.connections,
       sources: form.sources,
       excerpt: form.excerpt || undefined,
-      description: form.excerpt || undefined,
       category: form.category || undefined,
       last_updated: form.doc_date || undefined,
       status: form.review_status || undefined,

--- a/server/src/apps/admin/kb/documentHandlers.js
+++ b/server/src/apps/admin/kb/documentHandlers.js
@@ -358,9 +358,21 @@ function getKbGraph(req, res) {
     `)
     .all()
 
-  // Build title→id map for edge creation
-  const titleToId = {}
-  rows.forEach(row => { titleToId[row.title] = row.id })
+  // Build multi-key lookup: title, slug, and lowercase variants → id
+  // Tolerates wiki-link [[ ]], whitespace, case mismatches between connection refs and node titles
+  const lookup = {}
+  rows.forEach(row => {
+    const t = row.title ? String(row.title).trim() : ''
+    const s = row.slug ? String(row.slug).trim() : ''
+    if (t) {
+      lookup[t] = row.id
+      lookup[t.toLowerCase()] = lookup[t.toLowerCase()] || row.id
+    }
+    if (s) {
+      lookup[s] = lookup[s] || row.id
+      lookup[s.toLowerCase()] = lookup[s.toLowerCase()] || row.id
+    }
+  })
 
   const colors = { entity: '#8b5cf6', concept: '#6366f1', source: '#0ea5e9', synthesis: '#f59e0b' }
 
@@ -381,13 +393,17 @@ function getKbGraph(req, res) {
   rows.forEach(row => {
     const conns = parseTags(row.connections)
     for (const conn of conns) {
-      const targetId = titleToId[conn]
+      // Normalize: flatten nested arrays, strip wiki-link [[ ]], trim
+      const raw = Array.isArray(conn) ? String(conn[0] || '') : String(conn)
+      const normConn = raw.trim().replace(/^\[\[|\]\]$/g, '').trim()
+      if (!normConn) continue
+      const targetId = lookup[normConn] || lookup[normConn.toLowerCase()]
       if (targetId && targetId !== row.id) {
         const key = `${row.id}-${targetId}`
         const revKey = `${targetId}-${row.id}`
         if (!edgeSet.has(key) && !edgeSet.has(revKey)) {
           edgeSet.add(key)
-          edges.push({ source: String(row.id), target: String(targetId), label: conn })
+          edges.push({ source: String(row.id), target: String(targetId), label: normConn })
         }
       }
     }

--- a/server/src/apps/admin/kb/frontmatter.js
+++ b/server/src/apps/admin/kb/frontmatter.js
@@ -29,46 +29,46 @@ function parseFrontMatter(content) {
 
 /**
  * Build YAML front matter string from attributes object, then append body.
- * Known keys are ordered first; extra keys follow alphabetically.
+ * Uses js-yaml.dump() for proper escaping of special characters.
+ * Known keys are ordered first; extra keys follow in their original order.
  * @param {Object} attributes
  * @param {string} body
  * @returns {string} Full document content with YAML front matter + body
  */
 function buildFrontMatter(attributes, body) {
   const knownKeys = ["title", "type", "tags", "connections", "sources", "excerpt", "description", "category", "last_updated", "status"];
+
+  // Build ordered attrs object: known keys first, then extra keys
+  const orderedAttrs = {};
   const written = new Set();
-  const lines = [];
 
   for (const k of knownKeys) {
     const v = attributes[k];
     if (v === undefined || v === null || v === "") continue;
+    if (Array.isArray(v) && v.length === 0) continue;
+    orderedAttrs[k] = v;
     written.add(k);
-    if (Array.isArray(v)) {
-      if (v.length === 0) continue;
-      const items = v.map(i => String(i).includes(" ") ? `"${i}"` : String(i)).join(", ");
-      lines.push(`${k}: [${items}]`);
-    } else if (typeof v === "string" && /[:\-\[\]]/.test(v)) {
-      lines.push(`${k}: "${v}"`);
-    } else {
-      lines.push(`${k}: ${v}`);
-    }
   }
 
-  // Extra keys (not in known set)
-  for (const k of Object.keys(attributes).sort()) {
+  // Preserve extra (unknown) keys in their original order
+  for (const k of Object.keys(attributes)) {
     if (written.has(k)) continue;
     const v = attributes[k];
     if (v === undefined || v === null || v === "") continue;
-    if (Array.isArray(v)) {
-      if (v.length === 0) continue;
-      lines.push(`${k}: [${v.join(", ")}]`);
-    } else {
-      lines.push(`${k}: ${v}`);
-    }
+    if (Array.isArray(v) && v.length === 0) continue;
+    orderedAttrs[k] = v;
   }
 
-  if (lines.length === 0) return body || "";
-  return `---\n${lines.join("\n")}\n---\n${body || ""}`;
+  if (Object.keys(orderedAttrs).length === 0) return body || "";
+
+  const yamlStr = yaml.dump(orderedAttrs, {
+    lineWidth: -1,
+    noRefs: true,
+    quotingType: '"',
+    forceQuotes: false,
+  });
+
+  return `---\n${yamlStr}---\n${body || ""}`;
 }
 
 module.exports = { parseFrontMatter, buildFrontMatter };

--- a/server/src/apps/admin/kb/syncEngine.js
+++ b/server/src/apps/admin/kb/syncEngine.js
@@ -27,6 +27,22 @@ const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 const CONTENT_DIRS = ['wiki', 'notes'];
 
 /**
+ * Normalize an array of reference strings (connections, sources).
+ * - Flattens nested arrays (js-yaml may parse [[Doc A]] as [["Doc A"]])
+ * - Strips wiki-link [[ ]] brackets
+ * - Trims whitespace
+ * - Filters out empty values
+ */
+function normalizeRefs(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .flat(Infinity)
+    .filter(v => v !== null && v !== undefined)
+    .map(v => String(v).trim().replace(/^\[\[|\]\]$/g, '').trim())
+    .filter(Boolean);
+}
+
+/**
  * Walk a content directory recursively, calling callback for each .md file.
  * Skips hidden files (dot-prefixed), protects against symlink escapes.
  */
@@ -120,13 +136,8 @@ function importDocument(db, fileInfo, conflictStrategy, now, source) {
     ? JSON.stringify(attributes.tags.filter(Boolean))
     : JSON.stringify([]);
 
-  const connections = Array.isArray(attributes.connections)
-    ? JSON.stringify(attributes.connections.filter(Boolean))
-    : JSON.stringify([]);
-
-  const sources = Array.isArray(attributes.sources)
-    ? JSON.stringify(attributes.sources.filter(Boolean))
-    : JSON.stringify([]);
+  const connections = JSON.stringify(normalizeRefs(attributes.connections));
+  const sources = JSON.stringify(normalizeRefs(attributes.sources));
 
   const docDate = (attributes.last_updated && typeof attributes.last_updated === "string")
     ? attributes.last_updated.trim() : null;
@@ -138,11 +149,14 @@ function importDocument(db, fileInfo, conflictStrategy, now, source) {
     || (attributes.description && String(attributes.description).trim())
     || null;
 
-  // Extract category from the first path segment under the content dir
+  // Category priority: YAML attribute first, fall back to path segment
   // e.g., "wiki/project-a/file.md" → "project-a", "notes/daily/todo.md" → "daily"
-  const parts = fileInfo.relativePath.split("/");
-  const catStart = parts.length > 0 && CONTENT_DIRS.includes(parts[0]) ? 1 : 0;
-  const category = parts.length > catStart + 1 ? parts[catStart] : null;
+  let category = (attributes.category && String(attributes.category).trim()) || null;
+  if (!category) {
+    const parts = fileInfo.relativePath.split("/");
+    const catStart = parts.length > 0 && CONTENT_DIRS.includes(parts[0]) ? 1 : 0;
+    category = parts.length > catStart + 1 ? parts[catStart] : null;
+  }
 
   const existing = db
     .prepare("SELECT * FROM kb_documents WHERE original_path = ? AND source = ?")
@@ -421,7 +435,8 @@ async function fullExport(vaultPath, selectedPaths) {
 
       try {
         // Build YAML front matter from DB fields
-        const lastUpdated = doc.doc_date || doc.updated_at ? doc.updated_at.slice(0, 10) : null;
+        const lastUpdated = doc.doc_date
+          || (doc.updated_at ? doc.updated_at.slice(0, 10) : null);
         const yamlAttrs = {
           title: doc.title || undefined,
           type: doc.doc_type || undefined,


### PR DESCRIPTION
## Summary
Fixes two compounding issues:
1. **YAML fields lost after sync cycles** — special characters in array items broke the hand-written YAML emitter, causing the next js-yaml.load to fail and wipe all fields
2. **Node connections not displayed** — graph matching was too strict to handle wiki-link [[ ]], case differences, or whitespace

## Changes

### YAML round-trip safety
- `frontmatter.js` and `edit.vue`: replace hand-written YAML builder with `yaml.dump()`
- `syncEngine.js`: category reads from YAML first, then falls back to path segment
- `syncEngine.js`: fix `lastUpdated` operator precedence bug (`doc_date` was never written)
- `syncEngine.js`: `normalizeRefs()` flattens js-yaml nested arrays, strips `[[ ]]`, trims
- `edit.vue`: remove `description` duplicate write that was clobbering excerpt

### Graph connection matching
- `documentHandlers.js getKbGraph`: build multi-key lookup (title, slug, lowercase)
- Normalize each connection ref before lookup so `[[Doc A]]`, `doc a`, `Doc A ` all match

## Test plan
- [ ] Create doc with `connections: [Doc with: colon, Doc, comma]`, sync export, re-import, verify all fields preserved
- [ ] Repeat 3 sync cycles, verify no field loss
- [ ] Create A→B with `[[B]]`, verify edge appears in `/kb/graph`
- [ ] Test case-insensitive matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)