### PR TITLE
feat(kb-graph): add diagnostics for connection matching

### DIFF
--- a/server/src/apps/admin/kb/documentHandlers.js
+++ b/server/src/apps/admin/kb/documentHandlers.js
@@ -390,26 +390,49 @@ function getKbGraph(req, res) {
 
   const edgeSet = new Set()
   const edges = []
+  const unmatchedRefs = []  // diagnostic: connection strings that don't match any node
+  let totalRefs = 0
+  let matchedRefs = 0
   rows.forEach(row => {
     const conns = parseTags(row.connections)
+    if (!Array.isArray(conns)) return
     for (const conn of conns) {
+      totalRefs++
       // Normalize: flatten nested arrays, strip wiki-link [[ ]], trim
-      const raw = Array.isArray(conn) ? String(conn[0] || '') : String(conn)
-      const normConn = raw.trim().replace(/^\[\[|\]\]$/g, '').trim()
+      const raw = Array.isArray(conn) ? String(conn[0] || '') : String(conn || '')
+      const normConn = raw.trim().replace(/^\[\[/, '').replace(/\]\]$/, '').trim()
       if (!normConn) continue
       const targetId = lookup[normConn] || lookup[normConn.toLowerCase()]
       if (targetId && targetId !== row.id) {
+        matchedRefs++
         const key = `${row.id}-${targetId}`
         const revKey = `${targetId}-${row.id}`
         if (!edgeSet.has(key) && !edgeSet.has(revKey)) {
           edgeSet.add(key)
           edges.push({ source: String(row.id), target: String(targetId), label: normConn })
         }
+      } else {
+        unmatchedRefs.push({ from_title: row.title, from_id: row.id, ref: conn, normalized: normConn })
       }
     }
   })
 
-  res.json({ code: 200, data: { nodes, edges } })
+  // Log diagnostics to server console for debugging
+  console.log(`[kb-graph] nodes=${nodes.length} refs=${totalRefs} matched=${matchedRefs} edges=${edges.length} unmatched=${unmatchedRefs.length}`)
+  if (unmatchedRefs.length > 0 && unmatchedRefs.length <= 10) {
+    console.log(`[kb-graph] unmatched samples:`, JSON.stringify(unmatchedRefs.slice(0, 10), null, 2))
+  }
+
+  // Include diagnostics in response when ?debug=1 query param is present
+  const debugInfo = req.query.debug === '1' ? {
+    totalRefs,
+    matchedRefs,
+    unmatchedCount: unmatchedRefs.length,
+    unmatchedSamples: unmatchedRefs.slice(0, 20),
+    lookupSize: Object.keys(lookup).length,
+  } : undefined
+
+  res.json({ code: 200, data: { nodes, edges, ...(debugInfo ? { debug: debugInfo } : {}) } })
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
Add diagnostic logging to `getKbGraph` to help diagnose why connections aren't displayed:
- Log counts (nodes, refs, matched, edges, unmatched) to server console
- Accept `?debug=1` query param to include unmatched samples in response

## How to diagnose
1. After deploying, refresh the graph page
2. Check server logs for `[kb-graph]` line — shows counts
3. Or hit `/api/v2/admin/kb/documents/graph?debug=1` to see unmatched samples

## Likely findings
- `refs=0` → connections column is empty in DB (data lost in previous sync)
- `refs>0 matched=0` → title mismatch (connection strings don't match any node titles)
- `refs=matched edges=0` → bug in edge construction (unlikely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)