### PR TITLE
feat(sync): multi-source filesystem sync for api/manual/obsidian

### DIFF
--- a/admin/src/api/kb.ts
+++ b/admin/src/api/kb.ts
@@ -450,6 +450,9 @@ export interface SyncConfig {
   conflict_strategy: 'last_write_wins' | 'keep_both' | 'skip'
   last_sync_at: string | null
   selected_paths: string[]
+  sync_sources: string[]
+  api_export_dir: string
+  manual_export_dir: string
 }
 
 export interface SyncStatus {
@@ -489,6 +492,9 @@ export interface UpdateSyncConfigPayload {
   sync_interval_minutes?: number
   conflict_strategy?: 'last_write_wins' | 'keep_both' | 'skip'
   selected_paths?: string[]
+  sync_sources?: string[]
+  api_export_dir?: string
+  manual_export_dir?: string
 }
 
 export async function apiUpdateSyncConfig(

--- a/admin/src/views/kb/sync/index.vue
+++ b/admin/src/views/kb/sync/index.vue
@@ -11,6 +11,8 @@ import {
   NProgress,
   NDrawer,
   NDrawerContent,
+  NCheckbox,
+  NCheckboxGroup,
   useMessage,
 } from 'naive-ui'
 import {
@@ -94,6 +96,9 @@ const config = ref<SyncConfig>({
   conflict_strategy: 'last_write_wins',
   last_sync_at: null,
   selected_paths: [],
+  sync_sources: ['obsidian'],
+  api_export_dir: 'raw/api',
+  manual_export_dir: 'raw/manual',
 })
 
 // Folder selection toggle
@@ -342,7 +347,7 @@ async function loadConfig() {
   try {
     config.value = await apiGetSyncConfig()
     if (!config.value) {
-      config.value = { vault_path: '', auto_sync_enabled: false, sync_interval_minutes: 30, conflict_strategy: 'last_write_wins', last_sync_at: null, selected_paths: [] }
+      config.value = { vault_path: '', auto_sync_enabled: false, sync_interval_minutes: 30, conflict_strategy: 'last_write_wins', last_sync_at: null, selected_paths: [], sync_sources: ['obsidian'], api_export_dir: 'raw/api', manual_export_dir: 'raw/manual' }
     }
   } catch { /* ignore */ } finally {
     loading.value = false
@@ -370,6 +375,9 @@ async function handleSaveConfig() {
       sync_interval_minutes: config.value.sync_interval_minutes,
       conflict_strategy: config.value.conflict_strategy,
       selected_paths: config.value.selected_paths,
+      sync_sources: config.value.sync_sources,
+      api_export_dir: config.value.api_export_dir,
+      manual_export_dir: config.value.manual_export_dir,
     })
     message.success('配置已保存')
   } catch {
@@ -1138,6 +1146,42 @@ onMounted(() => {
               :disabled="!hasSyncPerm"
             />
             <span class="text-[10px] text-base-content/30 mt-0.5 block">容器内路径或挂载卷路径</span>
+          </div>
+
+          <!-- Sync sources -->
+          <div>
+            <label class="text-xs text-base-content/50 block mb-1.5">同步来源</label>
+            <NCheckboxGroup v-model:value="config.sync_sources">
+              <div class="flex flex-col gap-2">
+                <NCheckbox value="obsidian" label="Obsidian (wiki / notes)" :disabled="!hasSyncPerm" />
+                <NCheckbox value="api" label="API 文档 (raw / api)" :disabled="!hasSyncPerm" />
+                <NCheckbox value="manual" label="手动创建 (raw / manual)" :disabled="!hasSyncPerm" />
+              </div>
+            </NCheckboxGroup>
+          </div>
+
+          <!-- API export dir -->
+          <div v-if="config.sync_sources.includes('api')">
+            <label class="text-xs text-base-content/50 block mb-1.5">API 导出目录</label>
+            <NInput
+              v-model:value="config.api_export_dir"
+              placeholder="raw/api"
+              size="small"
+              :disabled="!hasSyncPerm"
+            />
+            <span class="text-[10px] text-base-content/30 mt-0.5 block">API 来源文档导出到该相对目录</span>
+          </div>
+
+          <!-- Manual export dir -->
+          <div v-if="config.sync_sources.includes('manual')">
+            <label class="text-xs text-base-content/50 block mb-1.5">手动导出目录</label>
+            <NInput
+              v-model:value="config.manual_export_dir"
+              placeholder="raw/manual"
+              size="small"
+              :disabled="!hasSyncPerm"
+            />
+            <span class="text-[10px] text-base-content/30 mt-0.5 block">手动创建文档导出到该相对目录</span>
           </div>
 
           <!-- Conflict strategy -->

--- a/server/src/apps/admin/kb/syncEngine.js
+++ b/server/src/apps/admin/kb/syncEngine.js
@@ -26,6 +26,55 @@ function computeChecksum(content) {
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 const CONTENT_DIRS = ['wiki', 'notes'];
 
+// Phase 12: Multi-source directory mapping
+const SOURCE_DIR_MAP = {
+  obsidian: ['wiki', 'notes'],
+  api: ['raw/api'],
+  manual: ['raw/manual'],
+};
+
+function getAllContentDirs(syncSources, apiExportDir, manualExportDir) {
+  const dirs = new Set();
+  const sources = Array.isArray(syncSources) ? syncSources : ['obsidian'];
+
+  if (sources.includes('obsidian')) {
+    CONTENT_DIRS.forEach(d => dirs.add(d));
+  }
+  if (sources.includes('api')) {
+    dirs.add(apiExportDir || 'raw/api');
+  }
+  if (sources.includes('manual')) {
+    dirs.add(manualExportDir || 'raw/manual');
+  }
+
+  return Array.from(dirs);
+}
+
+function getSourceFromPath(relativePath, apiExportDir, manualExportDir) {
+  const apiDir = (apiExportDir || 'raw/api').toLowerCase() + '/';
+  const manualDir = (manualExportDir || 'raw/manual').toLowerCase() + '/';
+  const lower = relativePath.toLowerCase();
+
+  if (lower.startsWith(apiDir)) return 'api';
+  if (lower.startsWith(manualDir)) return 'manual';
+  return 'obsidian';
+}
+
+function getExportTargetPath(doc, vaultPath, apiExportDir, manualExportDir) {
+  if (doc.source === 'obsidian') {
+    return doc.original_path;
+  }
+  if (doc.source === 'api') {
+    const dir = apiExportDir || 'raw/api';
+    return path.join(dir, `${doc.slug}.md`).replace(/\\/g, '/');
+  }
+  if (doc.source === 'manual') {
+    const dir = manualExportDir || 'raw/manual';
+    return path.join(dir, `${doc.slug}.md`).replace(/\\/g, '/');
+  }
+  return null;
+}
+
 /**
  * Normalize an array of reference strings (connections, sources).
  * - Flattens nested arrays (js-yaml may parse [[Doc A]] as [["Doc A"]])
@@ -83,11 +132,12 @@ function matchSelectedPaths(relPath, selectedPaths) {
   return result;
 }
 
-function scanVault(vaultPath, selectedPaths) {
+function scanVault(vaultPath, selectedPaths, dirs) {
   const results = [];
   let scanned = 0, matched = 0;
+  const contentDirs = Array.isArray(dirs) && dirs.length > 0 ? dirs : CONTENT_DIRS;
 
-  for (const dir of CONTENT_DIRS) {
+  for (const dir of contentDirs) {
     const dirPath = path.join(vaultPath, dir);
     if (!fs.existsSync(dirPath)) { console.log(`[kb-sync] scanVault: ${dir} not found: ${dirPath}`); continue; }
     walkContentDir(dirPath, (full, relPath) => {
@@ -101,7 +151,7 @@ function scanVault(vaultPath, selectedPaths) {
     });
   }
 
-  console.log(`[kb-sync] scanVault: scanned=${scanned} matched=${matched} results=${results.length} selected=${JSON.stringify(selectedPaths)}`);
+  console.log(`[kb-sync] scanVault: scanned=${scanned} matched=${matched} results=${results.length} selected=${JSON.stringify(selectedPaths)} dirs=${JSON.stringify(contentDirs)}`);
   return results;
 }
 
@@ -151,11 +201,16 @@ function importDocument(db, fileInfo, conflictStrategy, now, source) {
 
   // Category priority: YAML attribute first, fall back to path segment
   // e.g., "wiki/project-a/file.md" → "project-a", "notes/daily/todo.md" → "daily"
+  // Phase 12: For api/manual dirs, don't infer category from path (raw/api/file.md → null)
   let category = (attributes.category && String(attributes.category).trim()) || null;
   if (!category) {
     const parts = fileInfo.relativePath.split("/");
-    const catStart = parts.length > 0 && CONTENT_DIRS.includes(parts[0]) ? 1 : 0;
-    category = parts.length > catStart + 1 ? parts[catStart] : null;
+    const firstDir = parts[0]?.toLowerCase();
+    const isRawDir = firstDir === 'raw' || !CONTENT_DIRS.includes(firstDir);
+    if (!isRawDir) {
+      const catStart = 1;
+      category = parts.length > catStart + 1 ? parts[catStart] : null;
+    }
   }
 
   const existing = db
@@ -269,28 +324,68 @@ async function importFromFiles(files, conflictStrategy, source) {
 
 /**
  * Full import from filesystem: scan vault, import each file, log results.
+ * Phase 12: Supports multi-source directories (obsidian → wiki/notes, api → raw/api, manual → raw/manual)
  */
-async function fullImport(vaultPath, conflictStrategy, selectedPaths) {
+async function fullImport(vaultPath, conflictStrategy, selectedPaths, syncConfig) {
   if (!acquireLock()) throw new Error("同步正在进行中，请稍后重试");
   const db = openDb();
   const now = new Date().toISOString();
+
+  const config = syncConfig || db.prepare("SELECT sync_sources, api_export_dir, manual_export_dir FROM kb_sync_config WHERE id = 1").get();
+  const syncSources = config?.sync_sources ? parseJsonArray(config.sync_sources) : ['obsidian'];
+  const apiExportDir = config?.api_export_dir || 'raw/api';
+  const manualExportDir = config?.manual_export_dir || 'raw/manual';
+  const contentDirs = getAllContentDirs(syncSources, apiExportDir, manualExportDir);
+
   try {
-    console.log(`[kb-sync] fullImport starting: vault=${vaultPath} dirs=${JSON.stringify(CONTENT_DIRS)} selected=${JSON.stringify(selectedPaths)}`);
-    const files = scanVault(vaultPath, selectedPaths);
+    console.log(`[kb-sync] fullImport starting: vault=${vaultPath} dirs=${JSON.stringify(contentDirs)} selected=${JSON.stringify(selectedPaths)} sources=${JSON.stringify(syncSources)}`);
+    const files = scanVault(vaultPath, selectedPaths, contentDirs);
     console.log(`[kb-sync] scanVault found ${files.length} files, starting import...`);
-    const result = await importFromFiles(files, conflictStrategy, "obsidian");
-    console.log(`[kb-sync] fullImport complete:`, JSON.stringify(result));
-    return result;
+
+    // Phase 12: Infer source from file path for each file
+    for (const f of files) {
+      f.inferredSource = getSourceFromPath(f.relativePath, apiExportDir, manualExportDir);
+    }
+
+    const summary = { imported: 0, updated: 0, skipped: 0, conflicted: 0, errors: 0 };
+    const logStmt = db.prepare(
+      `INSERT INTO kb_sync_logs (direction, file_path, document_id, status, checksum, detail, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    for (const f of files) {
+      try {
+        const result = importDocument(db, f, conflictStrategy, now, f.inferredSource);
+        const statusMap = { imported: "success", updated: "success", skipped: "skipped", conflict: "conflict" };
+        if (summary[result.action] !== undefined) summary[result.action]++;
+        logStmt.run(
+          "import",
+          f.relativePath,
+          result.id || null,
+          statusMap[result.action] || "error",
+          f.checksum,
+          result.detail || null,
+          now,
+        );
+      } catch (err) {
+        summary.errors++;
+        logStmt.run("import", f.relativePath, null, "error", f.checksum, err.message, now);
+      }
+    }
+
+    db.prepare("UPDATE kb_sync_config SET last_sync_at = ?, updated_at = ? WHERE id = 1").run(now, now);
+    try { db.pragma("wal_checkpoint(PASSIVE)"); } catch { /* ignore */ }
+
+    console.log(`[kb-sync] fullImport complete:`, JSON.stringify(summary));
+    return summary;
   } catch (err) {
     console.error("[kb-sync] fullImport error:", err.message);
-    // Write the error to sync logs so the UI can display it
     try {
       db.prepare(
         "INSERT INTO kb_sync_logs (direction, file_path, status, detail, created_at) VALUES (?, ?, ?, ?, ?)",
       ).run("import", vaultPath, "error", `导入异常: ${err.message}`, now);
     } catch { /* ignore */ }
-    const summary = { imported: 0, updated: 0, skipped: 0, conflicted: 0, errors: 1 };
-    return summary;
+    return { imported: 0, updated: 0, skipped: 0, conflicted: 0, errors: 1 };
   } finally {
     releaseLock();
   }
@@ -396,13 +491,19 @@ function parseTags(raw) {
 }
 
 /**
- * Full export: write all obsidian-sourced documents back to the vault as .md files.
+ * Full export: write documents back to the vault as .md files.
+ * Phase 12: Supports multi-source export (obsidian, api, manual).
  * Builds YAML front matter from DB fields + body from content_markdown.
  */
-async function fullExport(vaultPath, selectedPaths) {
+async function fullExport(vaultPath, selectedPaths, syncConfig) {
   if (!acquireLock()) throw new Error("同步正在进行中，请稍后重试");
   const db = openDb();
   const now = new Date().toISOString();
+
+  const config = syncConfig || db.prepare("SELECT sync_sources, api_export_dir, manual_export_dir FROM kb_sync_config WHERE id = 1").get();
+  const syncSources = config?.sync_sources ? parseJsonArray(config.sync_sources) : ['obsidian'];
+  const apiExportDir = config?.api_export_dir || 'raw/api';
+  const manualExportDir = config?.manual_export_dir || 'raw/manual';
 
   const logStmt = db.prepare(
     `INSERT INTO kb_sync_logs (direction, file_path, document_id, status, checksum, detail, created_at)
@@ -412,18 +513,22 @@ async function fullExport(vaultPath, selectedPaths) {
   const summary = { exported: 0, skipped: 0, errors: 0 };
 
   try {
-    // Ensure content directories exist
+    // Ensure base content directories exist
     for (const dir of CONTENT_DIRS) fs.mkdirSync(path.join(vaultPath, dir), { recursive: true });
+    if (syncSources.includes('api')) fs.mkdirSync(path.join(vaultPath, apiExportDir), { recursive: true });
+    if (syncSources.includes('manual')) fs.mkdirSync(path.join(vaultPath, manualExportDir), { recursive: true });
 
+    // Build source IN clause
+    const placeholders = syncSources.map(() => '?').join(',');
     const docs = db
-      .prepare("SELECT * FROM kb_documents WHERE source = 'obsidian'")
-      .all();
+      .prepare(`SELECT * FROM kb_documents WHERE source IN (${placeholders})`)
+      .all(...syncSources);
 
     for (const doc of docs) {
-      const targetPath = doc.original_path;
+      const targetPath = getExportTargetPath(doc, vaultPath, apiExportDir, manualExportDir);
       if (!targetPath) {
         summary.errors++;
-        logStmt.run("export", `doc-${doc.id}`, doc.id, "error", null, "missing original_path", now);
+        logStmt.run("export", `doc-${doc.id}`, doc.id, "error", null, "missing target_path", now);
         continue;
       }
 
@@ -460,14 +565,20 @@ async function fullExport(vaultPath, selectedPaths) {
           continue;
         }
 
-        // Write file (targetPath includes content dir prefix, e.g. "wiki/file.md")
+        // Write file
         const fullPath = path.join(vaultPath, targetPath);
         fs.mkdirSync(path.dirname(fullPath), { recursive: true });
         fs.writeFileSync(fullPath, fullContent, "utf8");
 
-        // Update checksum in DB
-        db.prepare("UPDATE kb_documents SET checksum = ?, updated_at = ? WHERE id = ?")
-          .run(checksum, now, doc.id);
+        // Update original_path and checksum in DB for api/manual docs
+        const needsPathUpdate = (doc.source === 'api' || doc.source === 'manual') && doc.original_path !== targetPath;
+        if (needsPathUpdate) {
+          db.prepare("UPDATE kb_documents SET checksum = ?, updated_at = ?, original_path = ? WHERE id = ?")
+            .run(checksum, now, targetPath, doc.id);
+        } else {
+          db.prepare("UPDATE kb_documents SET checksum = ?, updated_at = ? WHERE id = ?")
+            .run(checksum, now, doc.id);
+        }
 
         summary.exported++;
         logStmt.run("export", targetPath, doc.id, "success", checksum, null, now);
@@ -494,4 +605,9 @@ async function fullExport(vaultPath, selectedPaths) {
   }
 }
 
-module.exports = { scanVault, scanVaultPaths, scanVaultChecksums, buildFileTree, importDocument, fullImport, importFromFiles, fullExport, computeChecksum, acquireLock, releaseLock, isRunning, MAX_FILE_SIZE, CONTENT_DIRS };
+function parseJsonArray(raw) {
+  if (!raw) return [];
+  try { return JSON.parse(raw); } catch { return []; }
+}
+
+module.exports = { scanVault, scanVaultPaths, scanVaultChecksums, buildFileTree, importDocument, fullImport, importFromFiles, fullExport, computeChecksum, acquireLock, releaseLock, isRunning, MAX_FILE_SIZE, CONTENT_DIRS, getAllContentDirs, getSourceFromPath, getExportTargetPath, parseJsonArray };

--- a/server/src/apps/admin/kb/syncHandlers.js
+++ b/server/src/apps/admin/kb/syncHandlers.js
@@ -5,10 +5,9 @@ const { nowIso, toInt } = require("../../../utils");
 const syncEngine = require("./syncEngine");
 const kbSync = require("../../../services/kbSync");
 
-const CONTENT_DIRS = syncEngine.CONTENT_DIRS || ['wiki', 'notes'];
-
-function hasContentDir(vaultPath) {
-  return CONTENT_DIRS.some(d => fs.existsSync(path.join(vaultPath, d)));
+function hasContentDir(vaultPath, dirs) {
+  const checkDirs = Array.isArray(dirs) && dirs.length > 0 ? dirs : (syncEngine.CONTENT_DIRS || ['wiki', 'notes']);
+  return checkDirs.some(d => fs.existsSync(path.join(vaultPath, d)));
 }
 
 function parseJsonArray(raw) {
@@ -49,6 +48,9 @@ function getSyncConfig(_req, res) {
           conflict_strategy: config.conflict_strategy,
           last_sync_at: config.last_sync_at,
           selected_paths: parseJsonArray(config.selected_paths),
+          sync_sources: parseJsonArray(config.sync_sources),
+          api_export_dir: config.api_export_dir,
+          manual_export_dir: config.manual_export_dir,
         }
       : null,
   });
@@ -59,6 +61,7 @@ function updateSyncConfig(req, res) {
   const now = nowIso();
   const {
     vault_path, auto_sync_enabled, sync_interval_minutes, conflict_strategy, selected_paths,
+    sync_sources, api_export_dir, manual_export_dir,
   } = req.body || {};
 
   const existing = db.prepare("SELECT * FROM kb_sync_config WHERE id = 1").get();
@@ -72,17 +75,23 @@ function updateSyncConfig(req, res) {
     sync_interval_minutes: sync_interval_minutes ?? existing.sync_interval_minutes,
     conflict_strategy: conflict_strategy ?? existing.conflict_strategy,
     selected_paths: selected_paths !== undefined ? JSON.stringify(selected_paths) : existing.selected_paths,
+    sync_sources: sync_sources !== undefined ? JSON.stringify(sync_sources) : existing.sync_sources,
+    api_export_dir: api_export_dir ?? existing.api_export_dir,
+    manual_export_dir: manual_export_dir ?? existing.manual_export_dir,
     updated_at: now,
   };
 
   db.prepare(
-    `UPDATE kb_sync_config SET vault_path=?, auto_sync_enabled=?, sync_interval_minutes=?, conflict_strategy=?, selected_paths=?, updated_at=? WHERE id=1`,
+    `UPDATE kb_sync_config SET vault_path=?, auto_sync_enabled=?, sync_interval_minutes=?, conflict_strategy=?, selected_paths=?, sync_sources=?, api_export_dir=?, manual_export_dir=?, updated_at=? WHERE id=1`,
   ).run(
     updates.vault_path,
     updates.auto_sync_enabled,
     updates.sync_interval_minutes,
     updates.conflict_strategy,
     updates.selected_paths,
+    updates.sync_sources,
+    updates.api_export_dir,
+    updates.manual_export_dir,
     updates.updated_at,
   );
 
@@ -115,7 +124,12 @@ async function triggerImport(req, res) {
 
   try {
     const selected = parseJsonArray(config.selected_paths);
-    await syncEngine.fullImport(config.vault_path, config.conflict_strategy || "last_write_wins", selected.length > 0 ? selected : null);
+    await syncEngine.fullImport(
+      config.vault_path,
+      config.conflict_strategy || "last_write_wins",
+      selected.length > 0 ? selected : null,
+      config,
+    );
   } catch (err) {
     console.error("[kb-sync] import failed:", err.message);
     try {
@@ -140,8 +154,12 @@ async function triggerExport(req, res) {
   }
 
   // Validate at least one content directory exists
-  if (!hasContentDir(config.vault_path)) {
-    return res.status(400).json({ code: 400, message: `仓库路径下未找到 ${CONTENT_DIRS.join('/')} 子目录，请先创建或导入数据` });
+  const syncSources = config?.sync_sources ? parseJsonArray(config.sync_sources) : ['obsidian'];
+  const apiExportDir = config?.api_export_dir || 'raw/api';
+  const manualExportDir = config?.manual_export_dir || 'raw/manual';
+  const contentDirs = syncEngine.getAllContentDirs(syncSources, apiExportDir, manualExportDir);
+  if (!hasContentDir(config.vault_path, contentDirs)) {
+    return res.status(400).json({ code: 400, message: `仓库路径下未找到 ${contentDirs.join('/')} 子目录，请先创建或导入数据` });
   }
 
   auditLog(db, req, "trigger_export", config.vault_path, "触发平台→Obsidian导出");
@@ -149,7 +167,7 @@ async function triggerExport(req, res) {
 
   try {
     const selected = parseJsonArray(config.selected_paths);
-    await syncEngine.fullExport(config.vault_path, selected.length > 0 ? selected : null);
+    await syncEngine.fullExport(config.vault_path, selected.length > 0 ? selected : null, config);
   } catch (err) {
     console.error("[kb-sync] export failed:", err.message);
     try {
@@ -267,9 +285,13 @@ async function testFilesystem(req, res) {
     }
 
     // Validate at least one content directory exists
-    const foundDirs = CONTENT_DIRS.filter(d => fs.existsSync(path.join(resolved, d)));
+    const syncSources = config?.sync_sources ? parseJsonArray(config.sync_sources) : ['obsidian'];
+    const apiExportDir = config?.api_export_dir || 'raw/api';
+    const manualExportDir = config?.manual_export_dir || 'raw/manual';
+    const contentDirs = syncEngine.getAllContentDirs(syncSources, apiExportDir, manualExportDir);
+    const foundDirs = contentDirs.filter(d => fs.existsSync(path.join(resolved, d)));
     if (foundDirs.length === 0) {
-      const detail = `路径下未找到 ${CONTENT_DIRS.join('/')} 子目录: ${resolved}`;
+      const detail = `路径下未找到 ${contentDirs.join('/')} 子目录: ${resolved}`;
       db.prepare(
         "INSERT INTO kb_sync_logs (direction, file_path, status, detail, created_at) VALUES (?, ?, ?, ?, ?)",
       ).run("import", vaultPath, "error", detail, now);
@@ -325,8 +347,11 @@ function getRemoteFiles(_req, res) {
 
     if (config && config.vault_path) {
       const vaultPath = path.resolve(config.vault_path);
-      // Use checksum scan so frontend can compare with synced files
-      files = syncEngine.scanVaultChecksums(vaultPath);
+      const syncSources = config.sync_sources ? parseJsonArray(config.sync_sources) : ['obsidian'];
+      const apiExportDir = config.api_export_dir || 'raw/api';
+      const manualExportDir = config.manual_export_dir || 'raw/manual';
+      const contentDirs = syncEngine.getAllContentDirs(syncSources, apiExportDir, manualExportDir);
+      files = syncEngine.scanVaultChecksums(vaultPath, contentDirs);
     }
 
     const tree = syncEngine.buildFileTree(files);
@@ -338,10 +363,13 @@ function getRemoteFiles(_req, res) {
 
 function getSyncedFiles(_req, res) {
   const db = openDb();
+  const config = db.prepare("SELECT sync_sources FROM kb_sync_config WHERE id = 1").get();
+  const syncSources = config?.sync_sources ? parseJsonArray(config.sync_sources) : ['obsidian'];
+  const placeholders = syncSources.map(() => '?').join(',');
 
   const docs = db
-    .prepare("SELECT id, title, original_path, checksum, status, word_count, updated_at FROM kb_documents WHERE source = 'obsidian' ORDER BY original_path")
-    .all();
+    .prepare(`SELECT id, title, original_path, checksum, status, word_count, updated_at, source FROM kb_documents WHERE source IN (${placeholders}) ORDER BY original_path`)
+    .all(...syncSources);
 
   // Cross-reference with latest sync log for per-file status
   const logMap = {};
@@ -389,11 +417,15 @@ function getSyncedFiles(_req, res) {
 
 function clearSyncedData(req, res) {
   const db = openDb();
-  const docResult = db.prepare("DELETE FROM kb_documents WHERE source = 'obsidian'").run();
+  const config = db.prepare("SELECT sync_sources FROM kb_sync_config WHERE id = 1").get();
+  const syncSources = config?.sync_sources ? parseJsonArray(config.sync_sources) : ['obsidian'];
+  const placeholders = syncSources.map(() => '?').join(',');
+
+  const docResult = db.prepare(`DELETE FROM kb_documents WHERE source IN (${placeholders})`).run(...syncSources);
   const logResult = db.prepare("DELETE FROM kb_sync_logs").run();
   db.prepare("UPDATE kb_sync_config SET last_sync_at = NULL, updated_at = ? WHERE id = 1").run(nowIso());
 
-  auditLog(db, req, "clear_synced", "obsidian", `清空同步数据: ${docResult.changes} 个文档, ${logResult.changes} 条日志`);
+  auditLog(db, req, "clear_synced", syncSources.join(','), `清空同步数据: ${docResult.changes} 个文档, ${logResult.changes} 条日志`);
 
   res.json({ code: 200, message: "已清空", data: { documentsDeleted: docResult.changes, logsDeleted: logResult.changes } });
 }

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -366,6 +366,11 @@ function migrate(db) {
   // Add selected_paths column for sync folder selection
   try { db.exec(`ALTER TABLE kb_sync_config ADD COLUMN selected_paths TEXT NOT NULL DEFAULT '[]'`); } catch { /* already exists */ }
 
+  // Phase 12: Multi-source filesystem sync (api/manual → raw/)
+  try { db.exec(`ALTER TABLE kb_sync_config ADD COLUMN sync_sources TEXT NOT NULL DEFAULT '["obsidian"]'`); } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE kb_sync_config ADD COLUMN api_export_dir TEXT NOT NULL DEFAULT 'raw/api'`); } catch { /* already exists */ }
+ try { db.exec(`ALTER TABLE kb_sync_config ADD COLUMN manual_export_dir TEXT NOT NULL DEFAULT 'raw/manual'`); } catch { /* already exists */ }
+
   // Relax kb_canvas_nodes type CHECK constraint to allow kb-doc types
   try {
     db.exec(`


### PR DESCRIPTION
## Summary
Extend KB-Obsidian sync engine to support multiple document sources (api / manual / obsidian) with bidirectional filesystem sync.

## Changes
- **db**: add `sync_sources`, `api_export_dir`, `manual_export_dir` to `kb_sync_config`
- **syncEngine**: infer `source` from file path during import; route exports to per-source directories
- **syncHandlers**: read/write new config fields
- **admin UI**: add source checkboxes + export directory inputs in sync config drawer
- **kb.ts**: extend TypeScript interfaces

## Test plan
- [ ] Publish KB doc via API → verify it exports to `raw/api/{slug}.md`
- [ ] Modify file in Obsidian `raw/api/` → import back to DB
- [ ] Toggle sync sources in admin UI → verify config persists