### PR TITLE
refactor(iot): adjust iot card list table columns

### DIFF
--- a/admin/src/views/iot/cards/index.vue
+++ b/admin/src/views/iot/cards/index.vue
@@ -541,7 +541,7 @@ function usagePercent(used: number | null | undefined, total: number | null | un
   return Math.min(100, Math.round((used / total) * 100))
 }
 
-// Table columns (list view — show all key fields)
+// Table columns (list view — show key fields)
 const tableColumns = computed(() => [
   {
     title: '卡号',
@@ -549,18 +549,6 @@ const tableColumns = computed(() => [
     width: 160,
     ellipsis: { tooltip: true },
     sorter: true,
-  },
-  {
-    title: 'ICCID',
-    key: 'iccid',
-    width: 180,
-    ellipsis: { tooltip: true },
-  },
-  {
-    title: 'MSISDN',
-    key: 'msisdn',
-    width: 130,
-    ellipsis: { tooltip: true },
   },
   {
     title: 'IMEI',
@@ -577,12 +565,10 @@ const tableColumns = computed(() => [
     },
   },
   {
-    title: '卡状态',
-    key: 'gprsState',
+    title: '位置',
+    key: 'realPosition',
     width: 100,
-    render(row: CardItem) {
-      return gprsStateTag(normalizeGprs(row.gprsState))
-    },
+    ellipsis: { tooltip: true },
   },
   {
     title: '开关机状态',
@@ -612,28 +598,10 @@ const tableColumns = computed(() => [
     },
   },
   {
-    title: '剩余',
-    key: 'comboResidue',
-    width: 90,
-    sorter: true,
-    render(row: CardItem) {
-      const v = row.comboResidue
-      if (v === null || v === undefined) return '-'
-      if (v >= 1024) return (v / 1024).toFixed(1) + 'G'
-      return v.toFixed(0) + 'M'
-    },
-  },
-  {
     title: '到期时间',
     key: 'endTime',
     width: 110,
     sorter: true,
-  },
-  {
-    title: '位置',
-    key: 'realPosition',
-    width: 100,
-    ellipsis: { tooltip: true },
   },
   {
     title: '开关',

--- a/admin/src/views/iot/cards/index.vue
+++ b/admin/src/views/iot/cards/index.vue
@@ -517,20 +517,6 @@ function gprsStateLabel(state: string | number | null | undefined) {
   return map[s] || '未知'
 }
 
-// Status tag VNode (for NDataTable render and NTag in templates)
-function gprsStateTag(state: string | number | null | undefined) {
-  const s = normalizeGprs(state)
-  const map: Record<string, { label: string; type: string }> = {
-    '0': { label: '未知', type: 'warning' },
-    '1': { label: '在线', type: 'success' },
-    '2': { label: '离线', type: 'default' },
-    '3': { label: '停机', type: 'error' },
-    '4': { label: '机卡分离', type: 'error' },
-  }
-  const t = map[s] || { label: '未知', type: 'warning' }
-  return h(NTag, { size: 'small', type: t.type as any }, () => t.label)
-}
-
 function operatorLabel(op: string) {
   const map: Record<string, string> = { '1': '联通', '2': '移动', '3': '电信' }
   return map[op] || op || '-'

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,6 +8,7 @@
       "name": "blog-design-server",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.9.0",
         "bcryptjs": "^3.0.2",
         "better-sqlite3": "^12.4.1",
         "cors": "^2.8.6",
@@ -135,6 +136,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -166,6 +179,24 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -470,6 +501,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
@@ -596,6 +639,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -805,6 +857,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1003,6 +1070,63 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1141,6 +1265,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -1215,6 +1354,19 @@
       },
       "engines": {
         "node": "^22.15.0 || ^24.0.0 || >=26.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/httpxy": {
@@ -2036,6 +2188,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/pstree.remy": {


### PR DESCRIPTION
## Summary

- Trim and reorder the IoT card management list view to show only the requested fields.
- New column order: **卡号 · IMEI · 运营商 · 位置 · 开关机状态 · 套餐 · 用量 · 到期时间 · 开关 · 操作**
- Drop `ICCID`, `MSISDN`, `卡状态 (gprsState)`, `剩余 (comboResidue)` from the list. They remain visible in the detail drawer.
- All fields already existed in the backend `CardItem` and DB; no API/DB changes needed.
- Also locks in `axios` and its transitive deps in `server/package-lock.json` to match `server/package.json` (was missing from the lock file).

## Files

- `admin/src/views/iot/cards/index.vue` — `tableColumns` computed (lines 545–675)
- `server/package-lock.json` — dependency lock sync

## Test plan

- [ ] Log in to admin and navigate to `/cms/iot/cards`
- [ ] Verify the 10 columns render in the listed order
- [ ] Verify sort still works on 卡号 / 用量 / 到期时间 headers
- [ ] Verify NSwitch on 开关 column toggles status with loading state
- [ ] Verify 查看 opens the right-side drawer (still contains ICCID/MSISDN/IMSI etc.)
- [ ] Verify 删除 shows confirmation popconfirm
- [ ] Verify filters (状态 / 运营商 / 区域 / 套餐) still work
- [ ] Verify card view + dashboard panels are unaffected
- [ ] Run `npx vue-tsc --noEmit` in `admin/` (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)