### PR TITLE
fix(iot): wire up table column sort to backend

### DIFF
--- a/admin/src/views/iot/cards/index.vue
+++ b/admin/src/views/iot/cards/index.vue
@@ -134,14 +134,25 @@ const SORT_OPTIONS = [
   { label: '到期时间 ↓', value: 'end_time:desc' },
 ]
 
+// Map camelCase column keys (used by NDataTable) to snake_case sort keys
+// the backend recognizes. Keys not listed pass through unchanged so the
+// manual dropdown options (e.g. "combo_used:asc") keep working.
+const SORT_KEY_MAP: Record<string, string> = {
+  cardNo: 'card_no',
+  comboUsed: 'combo_used',
+  endTime: 'end_time',
+}
+
 function applySort(value: string) {
   if (!value) {
     table.query.sortKey = ''
     table.query.sortOrder = 'desc'
   } else {
-    const [key, order] = value.split(':')
-    table.query.sortKey = key
-    table.query.sortOrder = order as 'asc' | 'desc'
+    const [key, rawOrder] = value.split(':')
+    table.query.sortKey = SORT_KEY_MAP[key] || key
+    table.query.sortOrder = (rawOrder === 'ascend' ? 'asc'
+      : rawOrder === 'descend' ? 'desc'
+      : rawOrder) as 'asc' | 'desc'
   }
   table.refresh()
 }


### PR DESCRIPTION
## Summary

The IoT card list's table column sort click was broken:
- NDataTable emits `{ columnKey, order: 'ascend' | 'descend' }`
- `applySort` passed the camelCase `columnKey` straight to the API
- The backend (`listCards`) only accepts snake_case keys (`card_no`, `combo_used`, `end_time`) — unknown keys fell back to default `ORDER BY`
- The `ascend`/`descend` values also passed through unchanged, so the backend defaulted the order

## Fix

In `admin/src/views/iot/cards/index.vue`'s `applySort`:

- Added `SORT_KEY_MAP` to translate camelCase column keys to the snake_case keys the backend accepts.
- Normalized `ascend`/`descend` to `asc`/`desc`. Unlisted keys (used by the manual dropdown, e.g. `combo_used:asc`) pass through.

## Test plan

- [x] Click 卡号 header → API sends `sortKey=card_no&sortOrder=desc` (was `cardNo&descend`)
- [x] Click again → `sortKey=card_no&sortOrder=asc`, rows reorder to 01→02→03
- [x] Click 用量 header → `sortKey=combo_used&sortOrder=desc`, rows reorder to 512G→50G→1G
- [x] Manual dropdown sort still works (uses pre-built snake_case values that pass through the map)
- [ ] `npx vue-tsc -b` clean (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)